### PR TITLE
Feature/be more robust if db is down

### DIFF
--- a/src/main/java/org/avaje/datasource/pool/ConnectionPool.java
+++ b/src/main/java/org/avaje/datasource/pool/ConnectionPool.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A robust DataSource implementation.
@@ -132,7 +133,7 @@ public class ConnectionPool implements DataSourcePool {
   /**
    * The current alert.
    */
-  private boolean inWarningMode;
+  private AtomicBoolean inWarningMode = new AtomicBoolean();
 
   /**
    * The minimum number of connections this pool will maintain.
@@ -320,9 +321,8 @@ public class ConnectionPool implements DataSourcePool {
    */
   protected void notifyWarning(String msg) {
 
-    if (!inWarningMode) {
+    if (inWarningMode.compareAndSet(false, true)) {
       // send an Error to the event log...
-      inWarningMode = true;
       logger.warn(msg);
       if (notify != null) {
         String subject = "DataSourcePool [" + name + "] warning";
@@ -697,7 +697,7 @@ public class ConnectionPool implements DataSourcePool {
    */
   public void reset() {
     queue.reset(leakTimeMinutes);
-    inWarningMode = false;
+    inWarningMode.set(false);
   }
 
   /**

--- a/src/main/java/org/avaje/datasource/pool/ConnectionPool.java
+++ b/src/main/java/org/avaje/datasource/pool/ConnectionPool.java
@@ -326,7 +326,7 @@ public class ConnectionPool implements DataSourcePool {
       logger.warn(msg);
       if (notify != null) {
         String subject = "DataSourcePool [" + name + "] warning";
-        notify.dataSourceWarning(subject, msg);
+        notify.dataSourceWarning(subject, msg); // FIXME: When modifying DataSourceAlert interface, pass "name" or "this" instead of subject
       }
     }
   }
@@ -337,7 +337,11 @@ public class ConnectionPool implements DataSourcePool {
       dataSourceDownAlertSent = true;
       logger.error("FATAL: DataSourcePool [" + name + "] is down or has network error!!!", ex);
       if (notify != null) {
-        notify.dataSourceDown(name);
+        if (ex != null) {
+          notify.dataSourceDown(name + ", error: " + ex.getMessage()); // FIXME: consider passing exception as parameter
+        } else {
+          notify.dataSourceDown(name);
+        }
       }
     }
     if (dataSourceUp) {


### PR DESCRIPTION
Hello Rob, 

I've made some changes in the connectionpool:

1. Connection pool will not fail hard if database is not available on initalization 
2. DataSource alerts are only fired once in multi thread applications
3. Other threads are blocked, until the DataSource alert is processed completely. 

Use Case:

1. I cannot create a default Ebean server if DB is down when my web application starts.
2+3. If DB was not available on startup, I have to run DDL scripts when DB comes up the first time (this is done in the notifyDataSourceIsUp event. 

It would be great if you give me some feedback about this change. 

Cheers
Roland 