### PR TITLE
When 'failOnStart' is disabled, and the database was down at start up the pool does not recover by itself

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -589,8 +589,11 @@ public class DataSourceConfig {
   /**
    * Return true (default) if the DataSource should be fail on start.
    * <p>
-   * This enables to initialize the Ebean-Server if the db-server is not yet up.
-   * ({@link DataSourceAlert#dataSourceUp(javax.sql.DataSource)} is fired when DS gets up later.)
+   * If this is disabled, it allows to create a connection pool, even if the
+   * datasource is not available. (e.g. parallel start up of docker containers).
+   * It enables to initialize the Ebean-Server if the db-server is not yet up. In
+   * this case, a ({@link DataSourceAlert#dataSourceUp(javax.sql.DataSource)} is
+   * fired when DS gets up either immediately at start-up or later.)
    * </p>
    */
   public boolean isFailOnStart() {

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolDbOutageTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolDbOutageTest.java
@@ -1,0 +1,156 @@
+package io.ebean.datasource.pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.ebean.datasource.DataSourceAlert;
+import io.ebean.datasource.DataSourceConfig;
+
+public class ConnectionPoolDbOutageTest implements DataSourceAlert, WaitFor {
+
+  private static final Logger log = LoggerFactory.getLogger(ConnectionPoolDbOutageTest.class);
+  private String connString;
+  private Connection h2Conn;
+  
+  private int up;
+  private int down;
+  private int warn;
+  
+  
+  @AfterEach
+  void afterAll() throws SQLException {
+    h2Conn.close();
+  }
+  
+  /**
+   * Changes the password and closes all exisitng sessions.
+   */
+  void setPassword(String pw) throws SQLException {
+    List<Integer> sessions = new ArrayList<>();
+    try (Statement stmt = h2Conn.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT SESSION_ID from INFORMATION_SCHEMA.SESSIONS");
+      while (rs.next()) {
+        sessions.add(rs.getInt(1));
+      }
+    }
+    
+    try (Statement stmt = h2Conn.createStatement()) {
+      stmt.execute("alter user sa set password '" + pw + "'");
+    }
+    
+    h2Conn.close();
+    // reopen connection with new credentials and kill old session
+    h2Conn = DriverManager.getConnection(connString, "sa", pw);
+    for (Integer sessionId : sessions) {
+      try (Statement stmt = h2Conn.createStatement()) {
+        stmt.execute("call abort_session(" + sessionId + ")");
+      }
+    }
+  }
+
+  private DataSourceConfig config() {
+
+    DataSourceConfig config = new DataSourceConfig();
+    config.setDriver("org.h2.Driver");
+    config.setUrl(connString);
+    config.setUsername("sa");
+    config.setPassword("sa");
+    config.setMinConnections(3);
+    config.setMaxConnections(4);
+    config.setFailOnStart(false);
+    config.setHeartbeatFreqSecs(1);
+    config.setAlert(this);
+
+    return config;
+  }
+
+  @Test
+  public void testOfflineFromStart() throws InterruptedException, SQLException {
+    connString = "jdbc:h2:mem:testOfflineFromStart";
+    h2Conn = DriverManager.getConnection(connString, "sa", "unknown");
+    
+    DataSourceConfig config = config();
+    assertThat(down).isEqualTo(0);
+    ConnectionPool pool = new ConnectionPool("mem:testOfflineFromStart", config);
+    // 
+    waitFor(() -> {
+      assertThat(pool.isOnline()).isFalse();
+      assertThat(up).isEqualTo(0);
+      assertThat(down).isEqualTo(1);
+      assertThat(pool.size()).isEqualTo(0);
+    });
+
+    log.info("pool created ");
+
+    // now set the correct password and bring the DS up
+    setPassword("sa");
+    waitFor(() -> {
+      assertThat(pool.isOnline()).isTrue();
+      assertThat(up).isEqualTo(1);
+      assertThat(down).isEqualTo(1);
+      assertThat(pool.size()).isEqualTo(1);
+    });
+    
+  }
+
+  @Test
+  public void testOfflineDuringRun() throws InterruptedException, SQLException {
+    connString = "jdbc:h2:mem:testOfflineDuringRun";
+    h2Conn = DriverManager.getConnection(connString, "sa", "sa");
+  
+    DataSourceConfig config = config();
+    ConnectionPool pool = new ConnectionPool("testOfflineDuringRun", config);
+    waitFor(()-> {
+      assertThat(pool.isOnline()).isTrue();
+      assertThat(up).isEqualTo(1); // we expect an up event in "failOnStart=false" mode
+      assertThat(down).isEqualTo(0);
+      assertThat(pool.size()).isEqualTo(3);
+    });
+    log.info("pool created ");
+    
+    // simulate an outage
+    setPassword("outage");
+    waitFor(()-> {
+      assertThat(pool.isOnline()).isFalse();
+      assertThat(up).isEqualTo(1);
+      assertThat(down).isEqualTo(1);
+    });
+  
+    // recover from outage
+    setPassword("sa");
+    waitFor(()-> {
+      assertThat(pool.isOnline()).isTrue();
+      assertThat(up).isEqualTo(2);
+      assertThat(down).isEqualTo(1);
+    });
+  }
+
+  @Override
+  public void dataSourceUp(DataSource dataSource) {
+    up++;
+  }
+
+  @Override
+  public void dataSourceDown(DataSource dataSource, SQLException reason) {
+    down++;
+  }
+
+  @Override
+  public void dataSourceWarning(DataSource dataSource, String msg) {
+    warn++;
+  }
+}

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/WaitFor.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/WaitFor.java
@@ -1,0 +1,61 @@
+package io.ebean.datasource.pool;
+
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.ThrowableAssert;
+
+/**
+ * Interface that can extend classes for tests, so a test can wait for a
+ * condition to become true.
+ *
+ * @author Jonas P&ouml;hler, FOCONIS AG
+ */
+public interface WaitFor {
+
+  /**
+   * Tests if the action becomes correct (= will not throw errors) for up to 10
+   * seconds. The check for correctness is performed every 50ms.
+   *
+   * Useful for tests which want to check the result of an asynchronous processing
+   * thread without using Thread.sleep().
+   */
+  default void waitFor(final ThrowableAssert.ThrowingCallable action) {
+    waitFor(action, TimeUnit.SECONDS.toMillis(10));
+  }
+
+  /**
+   * Tests if the action becomes correct (= will not throw errors) during the
+   * specified <code>millis</code>. The check for correctness is performed every
+   * 50ms.
+   *
+   * Useful for tests which want to check the result of an asynchronous processing
+   * thread without using Thread.sleep().
+   */
+  default void waitFor(final ThrowableAssert.ThrowingCallable action, final long millis) {
+    long endNano = System.nanoTime() + millis * 1000000;
+    int wait = 1;
+    try {
+      while (endNano > System.nanoTime()) {
+        try {
+          action.call();
+          return;
+        } catch (Throwable t) {
+          Thread.sleep(wait);
+          // double the wait time
+          if (wait < 128) {
+            wait = wait * 2;
+          }
+        }
+      }
+      action.call();
+    } catch (Throwable t) {
+      throw WaitFor.<RuntimeException>sneakyThrow(t); // hide real exception
+      
+    }
+  }
+
+  static <T extends Throwable> T sneakyThrow(Throwable t) throws T {
+    throw (T) t;
+  }
+
+}


### PR DESCRIPTION
*Use case* 
In our environment, we have to deal with the situation, that a database isn't up when the application server starts. In this case, we show a "database not available" on the UI and wait until the database comes up
 
This PR changes the following things, when `failOnStart = false` is set. (It should noth change the default behaviour)

1. It will `startHeartBeatIfStopped()` and log status message even when the database is not reachable at startup. (old behaviour: only error message was logged)
   Starting the heartbeat enables auto recovery by the datasource itself.
2. Fire a dataSourceUp event when the DB comes up the first time. This is probably a regression by https://github.com/ebean-orm/ebean-datasource/commit/dcf33426946eea9558b7cca7291b715bb3755a35.
   - with `failOnStart = true` (default) nothing is changed. No 'up' event is fired the first time. If you get no exception when constructing the pool, you know, it is up. The next event would be a 'down' event, if the database goes down later.
   - with `failOnStart = false` you will always receive a 'up' or 'down' event after creating the pool. This has to be done, because you cannot safely determine, if the database was up at construction or recovers to up state a few seconds later (you could check `isOnline()`, but this is not atomic, so you do not know, which of the two situations have occured)

I've also written a test, that simulates the two situations

Cheers Roland
