### PR TITLE
Refactor tests - Remove Thread.Sleep to improve test speed

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -589,8 +589,11 @@ public class DataSourceConfig {
   /**
    * Return true (default) if the DataSource should be fail on start.
    * <p>
-   * This enables to initialize the Ebean-Server if the db-server is not yet up.
-   * ({@link DataSourceAlert#dataSourceUp(javax.sql.DataSource)} is fired when DS gets up later.)
+   * If this is disabled, it allows to create a connection pool, even if the
+   * datasource is not available. (e.g. parallel start up of docker containers).
+   * It enables to initialize the Ebean-Server if the db-server is not yet up. In
+   * this case, a ({@link DataSourceAlert#dataSourceUp(javax.sql.DataSource)} is
+   * fired when DS gets up either immediately at start-up or later.)
    * </p>
    */
   public boolean isFailOnStart() {

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolDbOutageTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolDbOutageTest.java
@@ -1,0 +1,156 @@
+package io.ebean.datasource.pool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.ebean.datasource.DataSourceAlert;
+import io.ebean.datasource.DataSourceConfig;
+
+public class ConnectionPoolDbOutageTest implements DataSourceAlert, WaitFor {
+
+  private static final Logger log = LoggerFactory.getLogger(ConnectionPoolDbOutageTest.class);
+  private String connString;
+  private Connection h2Conn;
+  
+  private int up;
+  private int down;
+  private int warn;
+  
+  
+  @AfterEach
+  void afterAll() throws SQLException {
+    h2Conn.close();
+  }
+  
+  /**
+   * Changes the password and closes all exisitng sessions.
+   */
+  void setPassword(String pw) throws SQLException {
+    List<Integer> sessions = new ArrayList<>();
+    try (Statement stmt = h2Conn.createStatement()) {
+      ResultSet rs = stmt.executeQuery("SELECT SESSION_ID from INFORMATION_SCHEMA.SESSIONS");
+      while (rs.next()) {
+        sessions.add(rs.getInt(1));
+      }
+    }
+    
+    try (Statement stmt = h2Conn.createStatement()) {
+      stmt.execute("alter user sa set password '" + pw + "'");
+    }
+    
+    h2Conn.close();
+    // reopen connection with new credentials and kill old session
+    h2Conn = DriverManager.getConnection(connString, "sa", pw);
+    for (Integer sessionId : sessions) {
+      try (Statement stmt = h2Conn.createStatement()) {
+        stmt.execute("call abort_session(" + sessionId + ")");
+      }
+    }
+  }
+
+  private DataSourceConfig config() {
+
+    DataSourceConfig config = new DataSourceConfig();
+    config.setDriver("org.h2.Driver");
+    config.setUrl(connString);
+    config.setUsername("sa");
+    config.setPassword("sa");
+    config.setMinConnections(3);
+    config.setMaxConnections(4);
+    config.setFailOnStart(false);
+    config.setHeartbeatFreqSecs(1);
+    config.setAlert(this);
+
+    return config;
+  }
+
+  @Test
+  public void testOfflineFromStart() throws InterruptedException, SQLException {
+    connString = "jdbc:h2:mem:testOfflineFromStart";
+    h2Conn = DriverManager.getConnection(connString, "sa", "unknown");
+    
+    DataSourceConfig config = config();
+    assertThat(down).isEqualTo(0);
+    ConnectionPool pool = new ConnectionPool("mem:testOfflineFromStart", config);
+    // 
+    waitFor(() -> {
+      assertThat(pool.isOnline()).isFalse();
+      assertThat(up).isEqualTo(0);
+      assertThat(down).isEqualTo(1);
+      assertThat(pool.size()).isEqualTo(0);
+    });
+
+    log.info("pool created ");
+
+    // now set the correct password and bring the DS up
+    setPassword("sa");
+    waitFor(() -> {
+      assertThat(pool.isOnline()).isTrue();
+      assertThat(up).isEqualTo(1);
+      assertThat(down).isEqualTo(1);
+      assertThat(pool.size()).isEqualTo(1);
+    });
+    
+  }
+
+  @Test
+  public void testOfflineDuringRun() throws InterruptedException, SQLException {
+    connString = "jdbc:h2:mem:testOfflineDuringRun";
+    h2Conn = DriverManager.getConnection(connString, "sa", "sa");
+  
+    DataSourceConfig config = config();
+    ConnectionPool pool = new ConnectionPool("testOfflineDuringRun", config);
+    waitFor(()-> {
+      assertThat(pool.isOnline()).isTrue();
+      assertThat(up).isEqualTo(1); // we expect an up event in "failOnStart=false" mode
+      assertThat(down).isEqualTo(0);
+      assertThat(pool.size()).isEqualTo(3);
+    });
+    log.info("pool created ");
+    
+    // simulate an outage
+    setPassword("outage");
+    waitFor(()-> {
+      assertThat(pool.isOnline()).isFalse();
+      assertThat(up).isEqualTo(1);
+      assertThat(down).isEqualTo(1);
+    });
+  
+    // recover from outage
+    setPassword("sa");
+    waitFor(()-> {
+      assertThat(pool.isOnline()).isTrue();
+      assertThat(up).isEqualTo(2);
+      assertThat(down).isEqualTo(1);
+    });
+  }
+
+  @Override
+  public void dataSourceUp(DataSource dataSource) {
+    up++;
+  }
+
+  @Override
+  public void dataSourceDown(DataSource dataSource, SQLException reason) {
+    down++;
+  }
+
+  @Override
+  public void dataSourceWarning(DataSource dataSource, String msg) {
+    warn++;
+  }
+}

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolOfflineTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolOfflineTest.java
@@ -11,7 +11,7 @@ import java.sql.SQLException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ConnectionPoolOfflineTest {
+public class ConnectionPoolOfflineTest implements WaitFor {
 
   private static final Logger log = LoggerFactory.getLogger(ConnectionPoolOfflineTest.class);
 
@@ -39,44 +39,47 @@ public class ConnectionPoolOfflineTest {
     assertThat(pool.isOnline()).isFalse();
     assertThat(pool.size()).isEqualTo(0);
     log.info("pool created ");
-    Thread.sleep(3000);
 
-    assertEquals(0, pool.getStatus(false).getFree());
-    assertEquals(0, pool.getStatus(false).getBusy());
-    assertThat(pool.size()).isEqualTo(0);
-
+    waitFor(() -> {
+      assertEquals(0, pool.getStatus(false).getFree());
+      assertEquals(0, pool.getStatus(false).getBusy());
+      assertThat(pool.size()).isEqualTo(0);
+    });
+    
     pool.online();
     log.info("pool online");
     assertThat(pool.isOnline()).isTrue();
     assertEquals(2, pool.getStatus(false).getFree());
     assertEquals(0, pool.getStatus(false).getBusy());
     assertThat(pool.size()).isEqualTo(2);
-
-    Thread.sleep(3000);
 
     pool.offline();
     log.info("pool offline");
-    assertThat(pool.isOnline()).isFalse();
-    assertEquals(0, pool.getStatus(false).getFree());
-    assertEquals(0, pool.getStatus(false).getBusy());
-    assertThat(pool.size()).isEqualTo(0);
-
-    Thread.sleep(3000);
+    waitFor(() -> {
+      assertThat(pool.isOnline()).isFalse();
+      assertEquals(0, pool.getStatus(false).getFree());
+      assertEquals(0, pool.getStatus(false).getBusy());
+      assertThat(pool.size()).isEqualTo(0);
+    });
 
     pool.online();
     log.info("pool online");
-    assertThat(pool.isOnline()).isTrue();
-    assertEquals(2, pool.getStatus(false).getFree());
-    assertEquals(0, pool.getStatus(false).getBusy());
-    assertThat(pool.size()).isEqualTo(2);
-    Thread.sleep(3000);
-
+    
+    waitFor(() -> {
+      assertThat(pool.isOnline()).isTrue();
+      assertEquals(2, pool.getStatus(false).getFree());
+      assertEquals(0, pool.getStatus(false).getBusy());
+      assertThat(pool.size()).isEqualTo(2);
+    });
+    
     pool.shutdown();
 
-    assertThat(pool.isOnline()).isFalse();
-    assertEquals(0, pool.getStatus(false).getFree());
-    assertEquals(0, pool.getStatus(false).getBusy());
-    assertThat(pool.size()).isEqualTo(0);
+    waitFor(() -> {
+      assertThat(pool.isOnline()).isFalse();
+      assertEquals(0, pool.getStatus(false).getFree());
+      assertEquals(0, pool.getStatus(false).getBusy());
+      assertThat(pool.size()).isEqualTo(0);
+    });
   }
 
   @Test
@@ -131,13 +134,13 @@ public class ConnectionPoolOfflineTest {
     assertEquals(1, pool.getStatus(false).getBusy()); // still 1 busy connection
     assertThat(pool.size()).isEqualTo(1);
 
-    // a bit of time to let busy connection finish and close
-    Thread.sleep(4000);
-
-    // all done now
-    assertEquals(0, pool.getStatus(false).getFree());
-    assertEquals(0, pool.getStatus(false).getBusy());
-    assertThat(pool.size()).isEqualTo(0);
+    // wait to let busy connection finish and close
+    waitFor(() -> {
+      // all done now
+      assertEquals(0, pool.getStatus(false).getFree());
+      assertEquals(0, pool.getStatus(false).getBusy());
+      assertThat(pool.size()).isEqualTo(0);
+    });
   }
 
   @Test

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTrimIdleTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTrimIdleTest.java
@@ -10,7 +10,7 @@ import java.util.TimerTask;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class ConnectionPoolTrimIdleTest {
+public class ConnectionPoolTrimIdleTest implements WaitFor {
 
   private ConnectionPool createPool() {
 
@@ -47,11 +47,10 @@ public class ConnectionPoolTrimIdleTest {
       assertThat(pool.size()).isEqualTo(4);
       assertThat(pool.getStatus(false).getFree()).isEqualTo(4);
 
-      Thread.sleep(6000);
-
-      assertThat(pool.getStatus(false).getFree()).isEqualTo(1);
-      assertThat(pool.size()).isEqualTo(1);
-
+      waitFor(() -> {
+        assertThat(pool.getStatus(false).getFree()).isEqualTo(1);
+        assertThat(pool.size()).isEqualTo(1);
+      });
     } finally {
       pool.shutdown();
     }
@@ -77,23 +76,25 @@ public class ConnectionPoolTrimIdleTest {
 
       // keep 4 connections busy
       Timer timer0 = createTimer(pool, 4);
-      Thread.sleep(9000);
 
-      assertThat(pool.getStatus(false).getFree()).isEqualTo(4);
+      waitFor(() -> {
+        assertThat(pool.getStatus(false).getFree()).isEqualTo(4);
+      });
       timer0.cancel();
 
       // keep 2 connections busy
       Timer timer1 = createTimer(pool, 2);
-      Thread.sleep(6000);
 
-      assertThat(pool.getStatus(false).getFree()).isEqualTo(2);
+      waitFor(() -> {
+        assertThat(pool.getStatus(false).getFree()).isEqualTo(2);
+      });
       timer1.cancel();
 
       // Go Idle
-      Thread.sleep(5000);
-      assertThat(pool.getStatus(false).getFree()).isEqualTo(1);
-      assertThat(pool.size()).isEqualTo(1);
-
+      waitFor(() -> {
+        assertThat(pool.getStatus(false).getFree()).isEqualTo(1);
+        assertThat(pool.size()).isEqualTo(1);
+      });
     } finally {
       pool.shutdown();
     }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/WaitFor.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/WaitFor.java
@@ -1,0 +1,61 @@
+package io.ebean.datasource.pool;
+
+import java.util.concurrent.TimeUnit;
+
+import org.assertj.core.api.ThrowableAssert;
+
+/**
+ * Interface that can extend classes for tests, so a test can wait for a
+ * condition to become true.
+ *
+ * @author Jonas P&ouml;hler, FOCONIS AG
+ */
+public interface WaitFor {
+
+  /**
+   * Tests if the action becomes correct (= will not throw errors) for up to 10
+   * seconds. The check for correctness is performed every 50ms.
+   *
+   * Useful for tests which want to check the result of an asynchronous processing
+   * thread without using Thread.sleep().
+   */
+  default void waitFor(final ThrowableAssert.ThrowingCallable action) {
+    waitFor(action, TimeUnit.SECONDS.toMillis(10));
+  }
+
+  /**
+   * Tests if the action becomes correct (= will not throw errors) during the
+   * specified <code>millis</code>. The check for correctness is performed every
+   * 50ms.
+   *
+   * Useful for tests which want to check the result of an asynchronous processing
+   * thread without using Thread.sleep().
+   */
+  default void waitFor(final ThrowableAssert.ThrowingCallable action, final long millis) {
+    long endNano = System.nanoTime() + millis * 1000000;
+    int wait = 1;
+    try {
+      while (endNano > System.nanoTime()) {
+        try {
+          action.call();
+          return;
+        } catch (Throwable t) {
+          Thread.sleep(wait);
+          // double the wait time
+          if (wait < 128) {
+            wait = wait * 2;
+          }
+        }
+      }
+      action.call();
+    } catch (Throwable t) {
+      throw WaitFor.<RuntimeException>sneakyThrow(t); // hide real exception
+      
+    }
+  }
+
+  static <T extends Throwable> T sneakyThrow(Throwable t) throws T {
+    throw (T) t;
+  }
+
+}


### PR DESCRIPTION
This will use the `waitFor` construct here for other tests.

Requires this PR https://github.com/ebean-orm/ebean-datasource/pull/49

Effective changes in this PR: https://github.com/ebean-orm/ebean-datasource/commit/d3a52554e7cec617e2b9f197166eda825c5890c6