### PR TITLE
Support setting non-standard isolation levels

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/TransactionIsolation.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/TransactionIsolation.java
@@ -25,7 +25,7 @@ final class TransactionIsolation {
       case -1:
         return "NotSet";
       default:
-        throw new RuntimeException("Transaction Isolation level [" + level + "] is not defined.");
+        return "UNKNOWN[" + level + "]"
     }
   }
 }


### PR DESCRIPTION
For JDBC drivers (like Informix) isolation level 5 is a valid value.  Given JDBC Connection.transactionIsolation is just an int, it doesn't make sense to limit the possible values to what is defined in JDBC Connection class