### PR TITLE
When schema specified, change to use connection.setSchema() rather than connection Properties

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/PostgresInitDatabase.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/PostgresInitDatabase.java
@@ -17,10 +17,14 @@ public class PostgresInitDatabase implements InitDatabase {
   public void run(Connection connection, DataSourceConfig config) throws SQLException {
     String username = config.getUsername();
     String password = config.getPassword();
-    log.log(System.Logger.Level.INFO, "Creating schema and role for {0}", username);
-    execute(connection, String.format("create schema if not exists %s", username));
+    String schema = config.getSchema();
+    if (schema == null) {
+      schema = username;
+    }
+    log.log(System.Logger.Level.INFO, "Creating schema {0} role {1}", schema, username);
+    execute(connection, String.format("create schema if not exists %s", schema));
     execute(connection, String.format("create role %s with login password '%s'", username, password));
-    execute(connection, String.format("grant all on schema %s to %s", username, username));
+    execute(connection, String.format("grant all on schema %s to %s", schema, username));
   }
 
   private void execute(Connection connection, String sql) throws SQLException {

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -41,6 +41,7 @@ final class ConnectionPool implements DataSourcePool {
   private final String driver;
   private final String url;
   private final String user;
+  private final String schema;
   private final String heartbeatsql;
   private final int heartbeatFreqSecs;
   private final int heartbeatTimeoutSeconds;
@@ -112,6 +113,7 @@ final class ConnectionPool implements DataSourcePool {
     this.applicationName = params.getApplicationName();
     this.clientInfo = params.getClientInfo();
     this.queue = new PooledConnectionQueue(this);
+    this.schema = params.getSchema();
     this.user = params.getUsername();
     if (user == null) {
       throw new DataSourceConfigurationException("DataSource user is not set? url is [" + url + "]");
@@ -123,10 +125,6 @@ final class ConnectionPool implements DataSourcePool {
     this.connectionProps = new Properties();
     this.connectionProps.setProperty("user", user);
     this.connectionProps.setProperty("password", pw);
-    final String schema = params.getSchema();
-    if (schema != null) {
-      this.connectionProps.setProperty("schema", schema);
-    }
 
     Map<String, String> customProperties = params.getCustomProperties();
     if (customProperties != null) {
@@ -429,6 +427,9 @@ final class ConnectionPool implements DataSourcePool {
     }
     if (readOnly) {
       conn.setReadOnly(true);
+    }
+    if (schema != null) {
+      conn.setSchema(schema);
     }
     if (applicationName != null) {
       try {


### PR DESCRIPTION
Using Properties with a properties.setProperty("schema", ..) is not supported by Postgres. Changing to use connection.setSchema() looks like a more robust approach.