### PR TITLE
Clear parameters/batch/warnings, when statement is returned to cache

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PstmtCache.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PstmtCache.java
@@ -67,6 +67,15 @@ final class PstmtCache extends LinkedHashMap<String, ExtendedPreparedStatement> 
     if (alreadyInCache != null) {
       return false;
     }
+    try {
+      // before putting a statement back to the cache, we will clear the parameters, batch and warnings
+      stmt.clearParameters();
+      stmt.clearBatch();
+      stmt.clearWarnings();
+    } catch (SQLException e) {
+      Log.error("Error clearing PreparedStatement", e);
+      return false;
+    }
     // add the returning prepared statement to the cache.
     // Note that the LRUCache will automatically close fully old unused
     // statements when the cache has hit its maximum size.


### PR DESCRIPTION
**Problem**

if a preparedStatement of the same SQL do not bind all parameters, the parameters from the last successful run were used.

What happens here:

1. Test creates a prepared statement, but do not bind all parameters -> exception expected
2. Test creates the same Pstmt and binds all parametes -> it works
3. Pstmt is put back to connection pool
4. Test executes step 1 again -> exception is expected, but Pstmt has still the bind values from step 2 attached

(The problem exists only, if same sql is used in a wrong way)

**Possible solution**
Clear bind values, when putting Pstmt back to cache.

**CHECKME:** I think it is a good idea to clear also the attached batch values and warnings before putting it back to the cache. (To save memory)

**Side note:** At least the H2 Jdbc(Prepared)Statement will hold a reference to the last returned resultset [here](https://github.com/h2database/h2database/blob/master/h2/src/main/org/h2/jdbc/JdbcStatement.java#L52)

If such a result is not closed, it contains also references to the whole data.
This could increase the memory footprint or maybe hold confidental information longer in the ram than wanted.

Maybe this can be cleared with `pstmt.getMoreResults(Statement.CLOSE_ALL_RESULTS)`

