### PR TITLE
Add support for password2 and transparent password rotation

### DIFF
--- a/ebean-datasource-api/pom.xml
+++ b/ebean-datasource-api/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.1</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -29,6 +29,7 @@ public class DataSourceConfig {
   private String url;
   private String username;
   private String password;
+  private String password2;
   private String schema;
   private String driver;
   private InitDatabase initDatabase;
@@ -81,6 +82,7 @@ public class DataSourceConfig {
     copy.readOnlyUrl = readOnlyUrl;
     copy.username = username;
     copy.password = password;
+    copy.password2 = password2;
     copy.schema = schema;
     copy.platform = platform;
     copy.ownerUsername = ownerUsername;
@@ -135,6 +137,9 @@ public class DataSourceConfig {
     }
     if (password == null) {
       password = other.password;
+    }
+    if (password2 == null) {
+      password2 = other.password2;
     }
     if (schema == null) {
       schema = other.schema;
@@ -251,6 +256,21 @@ public class DataSourceConfig {
    */
   public DataSourceConfig setPassword(String password) {
     this.password = password;
+    return this;
+  }
+
+  /**
+   * Return the database alternate password2.
+   */
+  public String getPassword2() {
+    return password2;
+  }
+
+  /**
+   * Set the database alternate password2.
+   */
+  public DataSourceConfig setPassword2(String password2) {
+    this.password2 = password2;
     return this;
   }
 
@@ -834,6 +854,7 @@ public class DataSourceConfig {
   private void loadSettings(ConfigPropertiesHelper properties) {
     username = properties.get("username", username);
     password = properties.get("password", password);
+    password2 = properties.get("password2", password2);
     schema = properties.get("schema", schema);
     platform = properties.get("platform", platform);
     ownerUsername = properties.get("ownerUsername", ownerUsername);

--- a/ebean-datasource/pom.xml
+++ b/ebean-datasource/pom.xml
@@ -22,35 +22,42 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.1</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-test-containers</artifactId>
-      <version>6.2</version>
+      <version>7.1</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.5.1</version>
+      <version>42.6.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.11</version>
+      <version>1.4.7</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk-platform-logging</artifactId>
+      <version>2.0.9</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-slf4j-jpl</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/ebean-datasource/src/test/resources/logback-test.xml
+++ b/ebean-datasource/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<configuration scan="true" scanPeriod="10 seconds">
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>TRACE</level>
+    </filter>
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INF0">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+  <logger name="java.lang" level="WARN"/>
+  <logger name="io.ebean" level="INFO"/>
+  <logger name="io.avaje.config" level="TRACE"/>
+  <logger name="io.ebean.docker" level="DEBUG"/>
+  <logger name="io.ebean.test" level="TRACE"/>
+
+</configuration>


### PR DESCRIPTION
That is, we can configure the pool with a second password, and when there is an error creating a new connection with the first password the pool attempts to switch over to the second password transparently to the application.