### PR TITLE
Add DataSourceConfig setName() and build() method to build DataSourcePool

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -12,12 +12,12 @@ import java.util.Properties;
  *
  * <pre>{@code
  *
- *   DataSourceConfig config = new DataSourceConfig()
- *     .setUrl("jdbc:postgresql://127.0.0.1:5432/unit");
- *     .setUsername("foo");
- *     .setPassword("bar");
- *
- *   DataSource pool = DataSourceFactory.create("app", config);
+ *   DataSourcePool pool = new DataSourceConfig()
+ *     .setName("test")
+ *     .setUrl("jdbc:h2:mem:tests")
+ *     .setUsername("sa")
+ *     .setPassword("")
+ *     .build();
  *
  * }</pre>
  */
@@ -25,6 +25,7 @@ public class DataSourceConfig {
 
   private static final String POSTGRES = "postgres";
 
+  private String name = "";
   private String readOnlyUrl;
   private String url;
   private String username;
@@ -158,6 +159,31 @@ public class DataSourceConfig {
       && driver == null
       && username == null
       && password == null;
+  }
+
+  /**
+   * Build and return the DataSourcePool.
+   * <pre>{@code
+   *
+   *   DataSourcePool pool = new DataSourceConfig()
+   *     .setName("test")
+   *     .setUrl("jdbc:h2:mem:tests")
+   *     .setUsername("sa")
+   *     .setPassword("")
+   *     .build();
+   *
+   * }</pre>
+   */
+  public DataSourcePool build() {
+    return DataSourceFactory.create(name, this);
+  }
+
+  /**
+   * Set the data source pool name.
+   */
+  public DataSourceConfig setName(String name) {
+    this.name = name;
+    return this;
   }
 
   /**

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/FactoryTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/FactoryTest.java
@@ -11,18 +11,18 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
 public class FactoryTest {
 
   @Test
   public void createPool() throws Exception {
 
-    DataSourceConfig config = new DataSourceConfig();
-    config.setDriver("org.h2.Driver");
-    config.setUrl("jdbc:h2:mem:tests");
-    config.setUsername("sa");
-    config.setPassword("");
-
-    DataSourcePool pool = DataSourceFactory.create("test", config);
+    DataSourcePool pool = new DataSourceConfig()
+      .setName("test")
+      .setUrl("jdbc:h2:mem:tests")
+      .setUsername("sa")
+      .setPassword("")
+      .build();
 
     try (Connection connection = pool.getConnection()) {
       try (PreparedStatement stmt = connection.prepareStatement("create table junk (acol varchar(10))")) {
@@ -35,14 +35,11 @@ public class FactoryTest {
   @Test
   public void dataSourceFactory_get_createPool() throws Exception {
 
-
-    DataSourceConfig config = new DataSourceConfig();
-    config.setDriver("org.h2.Driver");
-    config.setUrl("jdbc:h2:mem:tests2");
-    config.setUsername("sa");
-    config.setPassword("");
-
-    DataSourcePool pool = DataSourceFactory.create("test", config);
+    DataSourcePool pool = new DataSourceConfig()
+      .setUrl("jdbc:h2:mem:tests2")
+      .setUsername("sa")
+      .setPassword("")
+      .build();
 
     try (Connection connection = pool.getConnection()) {
       try (PreparedStatement stmt = connection.prepareStatement("create table junk (acol varchar(10))")) {
@@ -50,9 +47,7 @@ public class FactoryTest {
         connection.commit();
       }
     }
-
   }
-
 
   @Test
   public void testPreparedStatement() throws Exception {


### PR DESCRIPTION
Then the DataSourcePool can be created via build() rather than using the DataSourceFactory explicitly like:

    DataSourcePool pool = new DataSourceConfig()
     .setName("test")
     .setUrl("jdbc:h2:mem:tests")
     .setUsername("sa")
     .setPassword("")
     .build();