### PR TITLE
Add DataSourceConfig.load() methods that take properties

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/ConfigPropertiesHelper.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/ConfigPropertiesHelper.java
@@ -15,8 +15,8 @@ final class ConfigPropertiesHelper {
    * Construct with a prefix, serverName and properties.
    */
   ConfigPropertiesHelper(String prefix, String poolName, Properties properties) {
-    this.poolName = poolName;
     this.prefix = prefix;
+    this.poolName = poolName;
     this.properties = properties;
   }
 

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -861,16 +861,39 @@ public class DataSourceConfig {
   }
 
   /**
-   * Load the settings from the properties supplied.
+   * Load the settings from the properties with no prefix on the property names.
+   *
+   * @param properties the properties to configure the dataSource
+   */
+  public DataSourceConfig load(Properties properties) {
+    return load(properties, null);
+  }
+
+  /**
+   * Load the settings from the properties with the given prefix on the property names.
    * <p>
-   * You can use this when you have your own properties to use for configuration.
+   * For example, using a prefix of "my-db" then the username property key would be
+   * "my-db.username".
+   *
+   * @param properties the properties to configure the dataSource
+   * @param prefix the prefix of the property names.
+   */
+  public DataSourceConfig load(Properties properties, String prefix) {
+    loadSettings(new ConfigPropertiesHelper(prefix, null, properties));
+    return this;
+  }
+
+  /**
+   * Load the settings from the properties with "datasource" prefix on the property names.
+   * <p>
+   * For example, if the poolName is "hr" then the username property key would be:
+   * "datasource.hr.username".
    *
    * @param properties the properties to configure the dataSource
    * @param poolName the name of the specific dataSource pool (optional)
    */
   public DataSourceConfig loadSettings(Properties properties, String poolName) {
-    ConfigPropertiesHelper dbProps = new ConfigPropertiesHelper("datasource", poolName, properties);
-    loadSettings(dbProps);
+    loadSettings(new ConfigPropertiesHelper("datasource", poolName, properties));
     return this;
   }
 

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -1,6 +1,5 @@
 package io.ebean.datasource;
 
-import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -49,22 +48,22 @@ public class DataSourceConfigTest {
   @Test
   public void isEmpty() {
     DataSourceConfig config = new DataSourceConfig();
-    AssertionsForClassTypes.assertThat(config.isEmpty()).isTrue();
+    assertThat(config.isEmpty()).isTrue();
 
     config.setUrl("foo");
-    AssertionsForClassTypes.assertThat(config.isEmpty()).isFalse();
+    assertThat(config.isEmpty()).isFalse();
 
     config = new DataSourceConfig();
     config.setUsername("foo");
-    AssertionsForClassTypes.assertThat(config.isEmpty()).isFalse();
+    assertThat(config.isEmpty()).isFalse();
 
     config = new DataSourceConfig();
     config.setPassword("foo");
-    AssertionsForClassTypes.assertThat(config.isEmpty()).isFalse();
+    assertThat(config.isEmpty()).isFalse();
 
     config = new DataSourceConfig();
     config.setDriver("foo");
-    AssertionsForClassTypes.assertThat(config.isEmpty()).isFalse();
+    assertThat(config.isEmpty()).isFalse();
   }
 
   @Test
@@ -147,13 +146,35 @@ public class DataSourceConfigTest {
 
   @Test
   public void loadSettings() throws IOException {
-
-    DataSourceConfig config = new DataSourceConfig();
-
     Properties props = new Properties();
     props.load(getClass().getResourceAsStream("/example.properties"));
-    config.loadSettings(props, "foo");
 
+    var config = new DataSourceConfig().loadSettings(props, "foo");
+    assertConfigValues(config);
+  }
+
+  @Test
+  public void load_prefix() throws IOException {
+    Properties props = new Properties();
+    props.load(getClass().getResourceAsStream("/example2.properties"));
+
+    var config = new DataSourceConfig().load(props, "bar");
+    assertConfigValues(config);
+  }
+
+  @Test
+  public void load_noPrefix() throws IOException {
+    Properties props = new Properties();
+    props.load(getClass().getResourceAsStream("/example3.properties"));
+
+    var config = new DataSourceConfig().load(props);
+    assertConfigValues(config);
+
+    var config2 = new DataSourceConfig().load(props, null);
+    assertConfigValues(config2);
+  }
+
+  private static void assertConfigValues(DataSourceConfig config) {
     assertThat(config.getReadOnlyUrl()).isEqualTo("myReadOnlyUrl");
     assertThat(config.getUrl()).isEqualTo("myUrl");
     assertThat(config.getUsername()).isEqualTo("myusername");

--- a/ebean-datasource-api/src/test/resources/example2.properties
+++ b/ebean-datasource-api/src/test/resources/example2.properties
@@ -1,0 +1,7 @@
+bar.username=myusername
+bar.password=mypassword
+bar.schema=myschema
+bar.url=myUrl
+bar.readOnlyUrl=myReadOnlyUrl
+bar.applicationName=myApp
+bar.clientInfo=ClientUser=ciu;ClientHostname=cih

--- a/ebean-datasource-api/src/test/resources/example3.properties
+++ b/ebean-datasource-api/src/test/resources/example3.properties
@@ -1,0 +1,7 @@
+username=myusername
+password=mypassword
+schema=myschema
+url=myUrl
+readOnlyUrl=myReadOnlyUrl
+applicationName=myApp
+clientInfo=ClientUser=ciu;ClientHostname=cih


### PR DESCRIPTION
The existing loadSettings() MUST use the "datasource" prefix and these newly added load() methods allow for other prefixes or no prefixes to be used when configuring from properties.