### PR TITLE
With DataSourceBuilder.setDefaults() also set minConnections if ...

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -106,8 +106,8 @@ public interface DataSourceBuilder {
   DataSourceBuilder copy();
 
   /**
-   * Default the values for driver, url, username and password from another builder if
-   * they these properties not already been set.
+   * Default the values for driver, url, username, password and minConnections
+   * from another builder if these properties not already been set.
    */
   DataSourceBuilder setDefaults(DataSourceBuilder other);
 

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -154,6 +154,9 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     if (schema == null) {
       schema = other.getSchema();
     }
+    if (minConnections == 2 && other.getMinConnections() < 2) {
+      minConnections = other.getMinConnections();
+    }
     if (customProperties == null) {
       var otherCustomProps = other.getCustomProperties();
       if (otherCustomProps != null) {

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -113,6 +113,7 @@ public class DataSourceConfigTest {
     assertThat(readOnly.getUsername()).isEqualTo(config.getUsername());
     assertThat(readOnly.getPassword()).isEqualTo(config.getPassword());
     assertThat(readOnly.getSchema()).isEqualTo(config.getSchema());
+    assertThat(readOnly.getMinConnections()).isEqualTo(config.getMinConnections());
     assertThat(readOnly.getCustomProperties()).containsKeys("useSSL");
   }
 
@@ -120,6 +121,7 @@ public class DataSourceConfigTest {
   public void defaults_someOverride() {
 
     DataSourceConfig readOnly = new DataSourceConfig();
+    readOnly.setMinConnections(3);
     readOnly.setUsername("foo2");
     readOnly.setUrl("jdbc:postgresql://127.0.0.2:5432/unit");
 
@@ -132,6 +134,7 @@ public class DataSourceConfigTest {
     assertThat(readOnly.getDriver()).isEqualTo(config.getDriver());
     assertThat(readOnly.getUrl()).isEqualTo("jdbc:postgresql://127.0.0.2:5432/unit");
     assertThat(readOnly.getUsername()).isEqualTo("foo2");
+    assertThat(readOnly.getMinConnections()).isEqualTo(3);
 
   }
 
@@ -141,6 +144,7 @@ public class DataSourceConfigTest {
       .setUrl("jdbc:postgresql://127.0.0.1:5432/unit")
       .setUsername("foo")
       .setPassword("bar")
+      .setMinConnections(1)
       .addProperty("useSSL", false);
   }
 

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -229,8 +229,9 @@ final class ConnectionPool implements DataSourcePool {
       tryEnsureMinimumConnections();
     }
     startHeartBeatIfStopped();
-    Log.info("DataSource [{0}] autoCommit[{1}] transIsolation[{2}] min[{3}] max[{4}] in[{5}ms]",
-      name, autoCommit, description(transactionIsolation), minConnections, maxConnections, (System.currentTimeMillis() - start));
+    final var ro = readOnly ? "readOnly[true] " : "";
+    Log.info("DataSource [{0}] autoCommit[{1}] {2}transIsolation[{3}] min[{4}] max[{5}] in[{6}ms]",
+      name, autoCommit, ro, description(transactionIsolation), minConnections, maxConnections, (System.currentTimeMillis() - start));
   }
 
   /**

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/FactoryTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/FactoryTest.java
@@ -11,11 +11,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
-public class FactoryTest {
+class FactoryTest {
 
   @Test
-  public void createPool() throws Exception {
-
+  void createPool() throws Exception {
     DataSourcePool pool = new DataSourceConfig()
       .setName("test")
       .setUrl("jdbc:h2:mem:tests")
@@ -32,8 +31,27 @@ public class FactoryTest {
   }
 
   @Test
-  public void dataSourceFactory_get_createPool() throws Exception {
+  void readOnly() throws Exception {
+    DataSourcePool pool = DataSourcePool.builder()
+      .name("testReadOnly")
+      .url("jdbc:h2:mem:testReadOnly")
+      .username("sa")
+      .password("")
+      .readOnly(true)
+      .autoCommit(true)
+      .build();
 
+    try (Connection connection = pool.getConnection()) {
+      try (PreparedStatement stmt = connection.prepareStatement("create table junk (acol varchar(10))")) {
+        stmt.execute();
+        connection.commit();
+      }
+    }
+    pool.shutdown();
+  }
+
+  @Test
+  void dataSourceFactory_get_createPool() throws Exception {
     DataSourcePool pool = new DataSourceConfig()
       .setUrl("jdbc:h2:mem:tests2")
       .setUsername("sa")
@@ -49,8 +67,7 @@ public class FactoryTest {
   }
 
   @Test
-  public void testPreparedStatement() throws Exception {
-
+  void testPreparedStatement() throws Exception {
     DataSourcePool pool = DataSourcePool.builder()
       .setUrl("jdbc:h2:mem:tests")
       .setUsername("sa")


### PR DESCRIPTION
If minConnections is the default and the main minConnections is less than 2. This supports that case where the main connection pool has minConnections of 0 or 1 and is being "cloned" for a read-only connection pool.