### PR TITLE
Add shutdown hook - via DataSourcePool.builder().shutdownOnJvmExit(true)

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -691,6 +691,12 @@ public interface DataSourceBuilder {
   DataSourceBuilder setInitDatabaseForPlatform(String platform);
 
   /**
+   * When set true a JVM shutdown hook is registered that will shutdown the
+   * connection pool on JVM exit if it has not already been shutdown.
+   */
+  DataSourceBuilder shutdownOnJvmExit(boolean shutdownOnJvmExit);
+
+  /**
    * Load the settings from the properties with no prefix on the property names.
    *
    * @param properties the properties to configure the dataSource
@@ -734,6 +740,11 @@ public interface DataSourceBuilder {
      * Return a DataSource that will be used to provide new connections or null.
      */
     DataSource dataSource();
+
+    /**
+     * Shut down pool on JVM exit.
+     */
+    boolean isShutdownOnJvmExit();
 
     /**
      * Return the connection properties including credentials and custom parameters.

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -80,6 +80,11 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private Properties clientInfo;
   private String applicationName;
 
+  /**
+   * should pool be shutdown on jvm exit.
+   */
+  private boolean shutdownOnJvmExit = true;
+
   @Override
   public Settings settings() {
     return this;
@@ -683,6 +688,22 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     return false;
   }
 
+  /**
+   * Shut down pool on JVM exit.
+   */
+  public boolean isShutdownOnJvmExit() {
+    return shutdownOnJvmExit;
+  }
+
+  /**
+   * If this is true (default) a cleaner thred is registered as JVM shutdown hook,
+   * that may shut down dangling DataSourcePools. Set to false to disable automatic
+   * shutdown.
+   */
+  public void setShutdownOnJvmExit(boolean shutdownOnJvmExit) {
+    this.shutdownOnJvmExit = shutdownOnJvmExit;
+  }
+
   @Override
   public DataSourceConfig load(Properties properties) {
     return load(properties, null);
@@ -735,6 +756,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     heartbeatTimeoutSeconds = properties.getInt("heartbeatTimeoutSeconds", heartbeatTimeoutSeconds);
     poolListener = properties.get("poolListener", poolListener);
     offline = properties.getBoolean("offline", offline);
+    shutdownOnJvmExit = properties.getBoolean("shutdownOnJvmExit", shutdownOnJvmExit);
 
     String isoLevel = properties.get("isolationLevel", _isolationLevel(isolationLevel));
     this.isolationLevel = _isolationLevel(isoLevel);

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -79,11 +79,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private DataSourcePoolListener listener;
   private Properties clientInfo;
   private String applicationName;
-
-  /**
-   * should pool be shutdown on jvm exit.
-   */
-  private boolean shutdownOnJvmExit = true;
+  private boolean shutdownOnJvmExit;
 
   @Override
   public Settings settings() {
@@ -688,20 +684,15 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     return false;
   }
 
-  /**
-   * Shut down pool on JVM exit.
-   */
+  @Override
   public boolean isShutdownOnJvmExit() {
     return shutdownOnJvmExit;
   }
 
-  /**
-   * If this is true (default) a cleaner thred is registered as JVM shutdown hook,
-   * that may shut down dangling DataSourcePools. Set to false to disable automatic
-   * shutdown.
-   */
-  public void setShutdownOnJvmExit(boolean shutdownOnJvmExit) {
+  @Override
+  public DataSourceConfig shutdownOnJvmExit(boolean shutdownOnJvmExit) {
     this.shutdownOnJvmExit = shutdownOnJvmExit;
+    return this;
   }
 
   @Override

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.LogManager;
 
 import static io.ebean.datasource.pool.TransactionIsolation.description;
 
@@ -86,6 +87,9 @@ final class ConnectionPool implements DataSourcePool {
   private final LongAdder pscPut = new LongAdder();
   private final LongAdder pscRem = new LongAdder();
 
+  private final boolean shutdownOnJvmExit;
+  private Thread shutdownHook;
+
   ConnectionPool(String name, DataSourceConfig params) {
     this.config = params;
     this.name = name;
@@ -114,6 +118,7 @@ final class ConnectionPool implements DataSourcePool {
     this.queue = new PooledConnectionQueue(this);
     this.schema = params.getSchema();
     this.user = params.getUsername();
+    this.shutdownOnJvmExit = params.isShutdownOnJvmExit();
     this.source = DriverDataSource.of(name, params);
     if (!params.isOffline()) {
       init();
@@ -179,6 +184,13 @@ final class ConnectionPool implements DataSourcePool {
       tryEnsureMinimumConnections();
     }
     startHeartBeatIfStopped();
+
+    if (shutdownOnJvmExit && shutdownHook == null) {
+      shutdownHook = new Thread(() -> shutdownPool(true, true));
+      shutdownHook.setName("Pool-Cleaner");
+      Runtime.getRuntime().addShutdownHook(shutdownHook);
+    }
+
     final var ro = readOnly ? "readOnly[true] " : "";
     Log.info("DataSource [{0}] {1}autoCommit[{2}] transIsolation[{3}] min[{4}] max[{5}] in[{6}ms]",
       name, ro, autoCommit, description(transactionIsolation), minConnections, maxConnections, (System.currentTimeMillis() - start));
@@ -634,19 +646,35 @@ final class ConnectionPool implements DataSourcePool {
    */
   @Override
   public void shutdown() {
-    shutdownPool(true);
+    shutdownPool(true, false);
   }
 
   @Override
   public void offline() {
-    shutdownPool(false);
+    shutdownPool(false, false);
   }
 
-  private void shutdownPool(boolean closeBusyConnections) {
+  private void shutdownPool(boolean closeBusyConnections, boolean fromShutdown) {
     stopHeartBeatIfRunning();
     PoolStatus status = queue.shutdown(closeBusyConnections);
-    Log.info("DataSource [{0}] shutdown {1}  psc[hit:{2} miss:{3} put:{4} rem:{5}]", name, status, pscHit, pscMiss, pscPut, pscRem);
     dataSourceUp.set(false);
+    if (fromShutdown) {
+      Log.warn("DataSource [{0}] shutdown on JVM exit {1}  psc[hit:{2} miss:{3} put:{4} rem:{5}]", name, status, pscHit, pscMiss, pscPut, pscRem);
+    } else {
+      Log.info("DataSource [{0}] shutdown {1}  psc[hit:{2} miss:{3} put:{4} rem:{5}]", name, status, pscHit, pscMiss, pscPut, pscRem);
+      removeShutdownHook();
+    }
+  }
+
+  private void removeShutdownHook() {
+    if (shutdownHook != null) {
+      try {
+        Runtime.getRuntime().removeShutdownHook(shutdownHook);
+      } catch (IllegalStateException e) {
+        // alredy in shutdown - may happen if shutdown is called by an application shutdown listener
+      }
+      shutdownHook = null;
+    }
   }
 
   @Override

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/ShutdownTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/ShutdownTest.java
@@ -1,29 +1,29 @@
 package io.ebean.datasource.test;
 
-import io.ebean.datasource.DataSourceConfig;
 import io.ebean.datasource.DataSourcePool;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-/**
- * @author Roland Praml, FOCONIS AG
- */
-public class ShutdownTest {
+class ShutdownTest {
 
   /**
    * The test itself will not fail, but if DB shutdown on exit does not work, Junit will quit with:
    * [ERROR] Surefire is going to kill self fork JVM. The exit has elapsed 30 seconds after System.exit(0)
    */
   @Test
-  void checkShutdownOnJvmExit() throws Exception {
-    for (int i = 0; i < 10; i++) {
-      DataSourcePool pool = new DataSourceConfig()
-        .setName("test")
-        .setUrl("jdbc:h2:mem:tests" + i)
-        .setUsername("sa")
-        .setPassword("")
+  void checkShutdownOnJvmExit() {
+    DataSourcePool aPool = null;
+    for (int i = 0; i < 4; i++) {
+      DataSourcePool pool = DataSourcePool.builder()
+        .name("test")
+        .url("jdbc:h2:mem:tests" + i)
+        .username("sa")
+        .password("")
+        .shutdownOnJvmExit(true)
         .build();
+      if (i == 1) {
+        aPool = pool;
+      }
     }
-    //pool.shutdown();
+    aPool.shutdown();
   }
 }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/ShutdownTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/ShutdownTest.java
@@ -1,0 +1,29 @@
+package io.ebean.datasource.test;
+
+import io.ebean.datasource.DataSourceConfig;
+import io.ebean.datasource.DataSourcePool;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Roland Praml, FOCONIS AG
+ */
+public class ShutdownTest {
+
+  /**
+   * The test itself will not fail, but if DB shutdown on exit does not work, Junit will quit with:
+   * [ERROR] Surefire is going to kill self fork JVM. The exit has elapsed 30 seconds after System.exit(0)
+   */
+  @Test
+  void checkShutdownOnJvmExit() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      DataSourcePool pool = new DataSourceConfig()
+        .setName("test")
+        .setUrl("jdbc:h2:mem:tests" + i)
+        .setUsername("sa")
+        .setPassword("")
+        .build();
+    }
+    //pool.shutdown();
+  }
+}


### PR DESCRIPTION
With `shutdownOnJvmExit(true)` then a JVM shutdown hook is registered and when the JVM exists then it will run and shutdown the DataSourcePool (unless it has already been shutdown).

```java
 DataSourcePool pool = DataSourcePool.builder()
        .name("test")
        .url("jdbc:h2:mem:test"i)
        .username("sa")
        .password("")
        .shutdownOnJvmExit(true)
        .build();
```

Note that this PR leaves the default for this to be **off by default**. This might change to default to on by default.