### PR TITLE
Improve trim skipping minConnections for max idle

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -496,33 +496,16 @@ final class ConnectionPool implements DataSourcePool {
     if (heartbeatsql == null) {
       return conn.isValid(heartbeatTimeoutSeconds);
     }
-    Statement stmt = null;
-    ResultSet rset = null;
-    try {
-      // It should only error IF the DataSource is down or a network issue
-      stmt = conn.createStatement();
+    // It should only error IF the DataSource is down or a network issue
+    try (Statement stmt = conn.createStatement()) {
       if (heartbeatTimeoutSeconds > 0) {
         stmt.setQueryTimeout(heartbeatTimeoutSeconds);
       }
-      rset = stmt.executeQuery(heartbeatsql);
-      conn.commit();
-
+      stmt.execute(heartbeatsql);
       return true;
-
     } finally {
-      try {
-        if (rset != null) {
-          rset.close();
-        }
-      } catch (SQLException e) {
-        Log.error("Error closing resultSet", e);
-      }
-      try {
-        if (stmt != null) {
-          stmt.close();
-        }
-      } catch (SQLException e) {
-        Log.error("Error closing statement", e);
+      if (!conn.getAutoCommit()) {
+        conn.rollback();
       }
     }
   }

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/FreeConnectionBuffer.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/FreeConnectionBuffer.java
@@ -1,9 +1,6 @@
 package io.ebean.datasource.pool;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 /**
  * A buffer designed especially to hold free pooled connections.
@@ -66,9 +63,9 @@ final class FreeConnectionBuffer {
   /**
    * Trim any inactive connections that have not been used since usedSince.
    */
-  int trim(long usedSince, long createdSince) {
+  int trim(int minSize, long usedSince, long createdSince) {
     int trimCount = 0;
-    Iterator<PooledConnection> iterator = freeBuffer.iterator();
+    ListIterator<PooledConnection> iterator = freeBuffer.listIterator(minSize);
     while (iterator.hasNext()) {
       PooledConnection pooledConnection = iterator.next();
       if (pooledConnection.shouldTrim(usedSince, createdSince)) {

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/FreeConnectionBufferTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/FreeConnectionBufferTest.java
@@ -1,16 +1,18 @@
 package io.ebean.datasource.pool;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.ListIterator;
 
-public class FreeConnectionBufferTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FreeConnectionBufferTest {
 
   @Test
-  public void test() {
+  void test() {
 
     FreeConnectionBuffer b = new FreeConnectionBuffer();
 
@@ -20,18 +22,18 @@ public class FreeConnectionBufferTest {
     // PooledConnection p3 = new PooledConnection("3");
 
     assertEquals(0, b.size());
-    assertEquals(true, b.isEmpty());
+    assertTrue(b.isEmpty());
 
     b.add(p0);
 
     assertEquals(1, b.size());
-    assertEquals(false, b.isEmpty());
+    assertFalse(b.isEmpty());
 
     PooledConnection r0 = b.remove();
-    assertTrue(p0 == r0);
+    assertThat(p0).isSameAs(r0);
 
     assertEquals(0, b.size());
-    assertEquals(true, b.isEmpty());
+    assertTrue(b.isEmpty());
 
     b.add(p0);
     b.add(p1);
@@ -72,6 +74,37 @@ public class FreeConnectionBufferTest {
     assertSame(p2, r7);
     assertEquals(0, b.size());
 
+  }
+
+  @Test
+  void listIterator() {
+    PooledConnection p0 = new PooledConnection("0");
+    PooledConnection p1 = new PooledConnection("1");
+    PooledConnection p2 = new PooledConnection("2");
+    PooledConnection p3 = new PooledConnection("3");
+
+    var list = new LinkedList<PooledConnection>();
+    list.add(p0);
+    list.add(p1);
+    list.add(p2);
+    list.add(p3);
+
+    var set1 = listIterate(list, 1);
+    assertThat(set1).hasSize(3);
+    assertThat(set1).contains(p1, p2, p3);
+
+    var set3 = listIterate(list, 3);
+    assertThat(set3).hasSize(1);
+    assertThat(set3).contains(p3);
+  }
+
+  private LinkedHashSet<PooledConnection> listIterate(LinkedList<PooledConnection> list, int position) {
+    ListIterator<PooledConnection> it = list.listIterator(position);
+    var set = new LinkedHashSet<PooledConnection>();
+    while (it.hasNext()) {
+      set.add(it.next());
+    }
+    return set;
   }
 
 }

--- a/ebean-datasource/src/test/resources/logback-test.xml
+++ b/ebean-datasource/src/test/resources/logback-test.xml
@@ -1,8 +1,5 @@
 <configuration scan="true" scanPeriod="10 seconds">
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-      <level>TRACE</level>
-    </filter>
     <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
       <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
@@ -17,5 +14,6 @@
   <logger name="io.avaje.config" level="TRACE"/>
   <logger name="io.ebean.docker" level="DEBUG"/>
   <logger name="io.ebean.test" level="TRACE"/>
+  <logger name="io.ebean.datasource" level="TRACE"/>
 
 </configuration>


### PR DESCRIPTION
Improve trimInactiveConnections() to:
- only trim on idle when freeList.size() > minSize
- only trim on maxAge when createdSince > 0
- skip the first minSize connections when trimming on idle
- only ensureMinConnections() when connections were trimmed

Also tidy code when using heartbeatSql via try-with-resources