### PR TITLE
Add validateOnHeartbeat with the ability to turn this off (typically for use with Lambda)

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -697,6 +697,15 @@ public interface DataSourceBuilder {
   DataSourceBuilder shutdownOnJvmExit(boolean shutdownOnJvmExit);
 
   /**
+   * Set whether the connection pool should be validated periodically.
+   * <p>
+   * This is enabled by default. Generally we only want to turn this
+   * off when using the pool with a Lambda function.
+   * @param validateOnHeartbeat Use false to disable heartbeat validation.
+   */
+  DataSourceBuilder validateOnHeartbeat(boolean validateOnHeartbeat);
+
+  /**
    * EXPERIMENTAL feature - Set to true when using in Lambda to enable an extra
    * check to detect when the function has been restored from suspension.
    */
@@ -752,6 +761,11 @@ public interface DataSourceBuilder {
      * Shut down pool on JVM exit.
      */
     boolean isShutdownOnJvmExit();
+
+    /**
+     * When true validate the pool when the heartbeat runs.
+     */
+    boolean isValidateOnHeartbeat();
 
     /**
      * Return the connection properties including credentials and custom parameters.

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -81,6 +81,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private String applicationName;
   private boolean shutdownOnJvmExit;
   private boolean useLambdaCheck;
+  private boolean validateOnHeartbeat = true;
 
   @Override
   public Settings settings() {
@@ -146,7 +147,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
 
   @Override
   public DataSourceConfig setDefaults(DataSourceBuilder builder) {
-    DataSourceBuilder.Settings other = builder.settings();
+    Settings other = builder.settings();
     if (driver == null) {
       driver = other.driver();
     }
@@ -705,6 +706,17 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   }
 
   @Override
+  public boolean isValidateOnHeartbeat() {
+    return validateOnHeartbeat;
+  }
+
+  @Override
+  public DataSourceConfig validateOnHeartbeat(boolean validateOnHeartbeat) {
+    this.validateOnHeartbeat = validateOnHeartbeat;
+    return this;
+  }
+
+  @Override
   public DataSourceBuilder useLambdaCheck(boolean useLambda) {
     this.useLambdaCheck = useLambda;
     return this;
@@ -768,6 +780,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     poolListener = properties.get("poolListener", poolListener);
     offline = properties.getBoolean("offline", offline);
     shutdownOnJvmExit = properties.getBoolean("shutdownOnJvmExit", shutdownOnJvmExit);
+    validateOnHeartbeat = properties.getBoolean("validateOnHeartbeat", validateOnHeartbeat);
     useLambdaCheck = properties.getBoolean("useLambdaCheck", useLambdaCheck);
 
     String isoLevel = properties.get("isolationLevel", _isolationLevel(isolationLevel));

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -170,6 +170,7 @@ public class DataSourceConfigTest {
     var config = new DataSourceConfig().loadSettings(props, "foo");
     assertConfigValues(config);
     assertThat(config.isShutdownOnJvmExit()).isTrue();
+    assertThat(config.isValidateOnHeartbeat()).isTrue();
     assertThat(config.useLambdaCheck()).isTrue();
   }
 
@@ -181,6 +182,7 @@ public class DataSourceConfigTest {
     var config = new DataSourceConfig().load(props, "bar");
     assertConfigValues(config);
     assertThat(config.isShutdownOnJvmExit()).isFalse();
+    assertThat(config.useLambdaCheck()).isFalse();
     assertThat(config.useLambdaCheck()).isFalse();
   }
 

--- a/ebean-datasource-api/src/test/resources/example.properties
+++ b/ebean-datasource-api/src/test/resources/example.properties
@@ -7,3 +7,4 @@ datasource.foo.applicationName=myApp
 datasource.foo.clientInfo=ClientUser=ciu;ClientHostname=cih
 datasource.foo.shutdownOnJvmExit=true
 datasource.foo.useLambdaCheck=true
+datasource.foo.validateOnHeartbeat=true

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
@@ -174,7 +174,6 @@ final class PooledConnectionQueue {
       }
       if (forceClose || c.shouldTrimOnReturn(lastResetTime, maxAgeMillis)) {
         c.closeConnectionFully(false);
-
       } else {
         freeList.add(c);
         notEmpty.signal();


### PR DESCRIPTION
With Lambda we might want to turn off validateOnHeartbeat such that the heartbeat only trims the connection pool and does not perform a background test on a connection.