### PR TITLE
Default validateOnHeartbeat = !System.getenv().containsKey("LAMBDA_TASK_ROOT");

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -80,7 +80,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private Properties clientInfo;
   private String applicationName;
   private boolean shutdownOnJvmExit;
-  private boolean validateOnHeartbeat = true;
+  private boolean validateOnHeartbeat = !System.getenv().containsKey("LAMBDA_TASK_ROOT");
 
   @Override
   public Settings settings() {


### PR DESCRIPTION
With this we can then remove the explicit experimental lambdaMode() and just auto detect it. When running in lambda we don't want to validate connections in a background task due to lambda suspend.