### PR TITLE
Resetting Schema and Catalog, when connection returend to pool

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionDelegator.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionDelegator.java
@@ -7,7 +7,6 @@ import java.util.concurrent.Executor;
 abstract class ConnectionDelegator implements Connection {
 
   private final Connection delegate;
-  protected String currentSchema;
 
   ConnectionDelegator(Connection delegate) {
     this.delegate = delegate;
@@ -18,12 +17,6 @@ abstract class ConnectionDelegator implements Connection {
    */
   Connection delegate() {
     return delegate;
-  }
-
-  @Override
-  public final void setSchema(String schema) throws SQLException {
-    delegate.setSchema(schema);
-    currentSchema = schema;
   }
 
   @Override

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/SchemaTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/SchemaTest.java
@@ -1,0 +1,92 @@
+package io.ebean.datasource.pool;
+
+import io.ebean.datasource.DataSourceConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class SchemaTest {
+
+  private final ConnectionPool pool;
+
+  SchemaTest() {
+    pool = createPool();
+  }
+
+  private ConnectionPool createPool() {
+    DataSourceConfig config = new DataSourceConfig();
+    config.setUrl("jdbc:h2:mem:tests");
+    config.setUsername("sa");
+    config.setPassword("");
+    config.setMinConnections(2);
+    config.setMaxConnections(4);
+
+    return new ConnectionPool("test", config);
+  }
+
+  @BeforeEach
+  void initTables() throws SQLException {
+    try (Connection conn = pool.getConnection()) {
+      Statement statement = conn.createStatement();
+      statement.execute("CREATE TABLE test (name VARCHAR(255))");
+      statement.execute("INSERT INTO test (name) VALUES ('default schema')");
+      statement.execute("CREATE SCHEMA SCHEMA1");
+      statement.execute("CREATE SCHEMA SCHEMA2");
+      conn.commit();
+    }
+    try (Connection conn = pool.getConnection()) {
+      String orig = conn.getSchema();
+      conn.setSchema("SCHEMA1");
+      Statement statement = conn.createStatement();
+      statement.execute("CREATE TABLE test (name VARCHAR(255))");
+      statement.execute("INSERT INTO test (name) VALUES ('schema1')");
+      conn.setSchema("SCHEMA2");
+      statement.execute("CREATE TABLE test (name VARCHAR(255))");
+      statement.execute("INSERT INTO test (name) VALUES ('schema2')");
+      conn.setSchema(orig);
+      conn.commit();
+    }
+  }
+
+  @AfterEach
+  void after() {
+    pool.shutdown();
+  }
+
+  @Test
+  void getConnectionWithSchemaSwitch() throws SQLException {
+    try (Connection conn = pool.getConnection()) {
+      Statement statement = conn.createStatement();
+      ResultSet rs = statement.executeQuery("SELECT name FROM test");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("name")).isEqualTo("default schema");
+    }
+    try (Connection conn = pool.getConnection()) {
+      conn.setSchema("SCHEMA1");
+      Statement statement = conn.createStatement();
+      ResultSet rs = statement.executeQuery("SELECT name FROM test");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("name")).isEqualTo("schema1");
+    }
+    try (Connection conn = pool.getConnection()) {
+      conn.setSchema("SCHEMA2");
+      Statement statement = conn.createStatement();
+      ResultSet rs = statement.executeQuery("SELECT name FROM test");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("name")).isEqualTo("schema2");
+    }
+    try (Connection conn = pool.getConnection()) {
+      Statement statement = conn.createStatement();
+      ResultSet rs = statement.executeQuery("SELECT name FROM test");
+      assertThat(rs.next()).isTrue();
+      assertThat(rs.getString("name")).isEqualTo("default schema");
+    }
+  }
+}


### PR DESCRIPTION
When a connection is taken from the pool and schema and/or catalog will be changed, the schema/catalog is not reset. So the next one will get a connection, that is not in the expected schema/catalog and might read the wrong data.

I've also refactored the change in https://github.com/ebean-orm/ebean-datasource/pull/5 a bit that it also handles the current catalog.

*Sidenotes:*
Currently, these setters are reset when connection is put back to pool:
- setAutocommit (already handled)
- setReadonly (already handled)
- setTransactionIsolation (already handled)
- setCatalog (handled in this PR)
- setSchema (handled in this PR)

Generally, we should think about all setters on the connection, if we either reset them or if we throw an exception, when someone tries to use them.
- setTypeMap
- setHoldability
- setNetworkTimeout
- setClientInfo
- setShardingKey (since java 9)