### PR TITLE
Use pool schema/catalog for original values, lazy initialise originalSchema if required

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -250,6 +250,11 @@ public interface DataSourceBuilder {
   }
 
   /**
+   * Set the default database catalog to use.
+   */
+  DataSourceBuilder catalog(String catalog);
+
+  /**
    * @deprecated - migrate to {@link #driver(String)}.
    */
   @Deprecated(forRemoval = true)
@@ -811,6 +816,11 @@ public interface DataSourceBuilder {
      * Return the database username.
      */
     String getSchema();
+
+    /**
+     * Return the database catalog.
+     */
+    String catalog();
 
     /**
      * Return the driver instance to use.

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -36,6 +36,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private String password;
   private String password2;
   private String schema;
+  private String catalog;
   private Driver driver;
   private Class<? extends Driver> driverClass;
   private String driverClassName;
@@ -103,6 +104,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     copy.password = password;
     copy.password2 = password2;
     copy.schema = schema;
+    copy.catalog = catalog;
     copy.platform = platform;
     copy.ownerUsername = ownerUsername;
     copy.ownerPassword = ownerPassword;
@@ -170,6 +172,9 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     }
     if (schema == null) {
       schema = other.getSchema();
+    }
+    if (catalog == null) {
+      catalog = other.catalog();
     }
     if (minConnections == 2 && other.getMinConnections() < 2) {
       minConnections = other.getMinConnections();
@@ -304,6 +309,17 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   @Override
   public DataSourceConfig setSchema(String schema) {
     this.schema = schema;
+    return this;
+  }
+
+  @Override
+  public String catalog() {
+    return catalog;
+  }
+
+  @Override
+  public DataSourceConfig catalog(String catalog) {
+    this.catalog = catalog;
     return this;
   }
 
@@ -740,6 +756,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     password = properties.get("password", password);
     password2 = properties.get("password2", password2);
     schema = properties.get("schema", schema);
+    catalog = properties.get("catalog", catalog);
     platform = properties.get("platform", platform);
     ownerUsername = properties.get("ownerUsername", ownerUsername);
     ownerPassword = properties.get("ownerPassword", ownerPassword);

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -77,6 +77,7 @@ public class DataSourceConfigTest {
     source.setUrl("url");
     source.setReadOnlyUrl("readOnlyUrl");
     source.setSchema("sch");
+    source.catalog("cat");
 
     Map<String,String> customSource = new LinkedHashMap<>();
     customSource.put("a","a");
@@ -90,6 +91,7 @@ public class DataSourceConfigTest {
     assertEquals("url", copy.getUrl());
     assertEquals("readOnlyUrl", copy.getReadOnlyUrl());
     assertEquals("sch", copy.getSchema());
+    assertEquals("cat", copy.catalog());
     assertEquals(42, copy.getMinConnections());
     assertEquals(45, copy.getMaxConnections());
 
@@ -113,6 +115,7 @@ public class DataSourceConfigTest {
     assertThat(readOnly.getUsername()).isEqualTo(config.getUsername());
     assertThat(readOnly.getPassword()).isEqualTo(config.getPassword());
     assertThat(readOnly.getSchema()).isEqualTo(config.getSchema());
+    assertThat(readOnly.catalog()).isEqualTo(config.catalog());
     assertThat(readOnly.getMinConnections()).isEqualTo(config.getMinConnections());
     assertThat(readOnly.getCustomProperties()).containsKeys("useSSL");
   }
@@ -258,6 +261,7 @@ public class DataSourceConfigTest {
     assertThat(config.getUsername()).isEqualTo("myusername");
     assertThat(config.getPassword()).isEqualTo("mypassword");
     assertThat(config.getSchema()).isEqualTo("myschema");
+    assertThat(config.catalog()).isEqualTo("mycat");
     assertThat(config.getApplicationName()).isEqualTo("myApp");
     Properties clientInfo = config.getClientInfo();
     assertThat(clientInfo.getProperty("ClientUser")).isEqualTo("ciu");

--- a/ebean-datasource-api/src/test/resources/example.properties
+++ b/ebean-datasource-api/src/test/resources/example.properties
@@ -1,6 +1,7 @@
 datasource.foo.username=myusername
 datasource.foo.password=mypassword
 datasource.foo.schema=myschema
+datasource.foo.catalog=mycat
 datasource.foo.url=myUrl
 datasource.foo.readOnlyUrl=myReadOnlyUrl
 datasource.foo.applicationName=myApp

--- a/ebean-datasource-api/src/test/resources/example2.properties
+++ b/ebean-datasource-api/src/test/resources/example2.properties
@@ -1,6 +1,7 @@
 bar.username=myusername
 bar.password=mypassword
 bar.schema=myschema
+bar.catalog=mycat
 bar.url=myUrl
 bar.readOnlyUrl=myReadOnlyUrl
 bar.applicationName=myApp

--- a/ebean-datasource-api/src/test/resources/example3.properties
+++ b/ebean-datasource-api/src/test/resources/example3.properties
@@ -1,6 +1,7 @@
 username=myusername
 password=mypassword
 schema=myschema
+catalog=mycat
 url=myUrl
 readOnlyUrl=myReadOnlyUrl
 applicationName=myApp

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -42,6 +42,7 @@ final class ConnectionPool implements DataSourcePool {
   private final List<String> initSql;
   private final String user;
   private final String schema;
+  private final String catalog;
   private final String heartbeatSql;
   private final int heartbeatFreqSecs;
   private final int heartbeatTimeoutSeconds;
@@ -119,6 +120,7 @@ final class ConnectionPool implements DataSourcePool {
     this.clientInfo = params.getClientInfo();
     this.queue = new PooledConnectionQueue(this);
     this.schema = params.getSchema();
+    this.catalog = params.catalog();
     this.user = params.getUsername();
     this.shutdownOnJvmExit = params.isShutdownOnJvmExit();
     this.source = DriverDataSource.of(name, params);
@@ -249,6 +251,14 @@ final class ConnectionPool implements DataSourcePool {
   @Override
   public int size() {
     return size.get();
+  }
+
+  String schema() {
+    return schema;
+  }
+
+  String catalog() {
+    return catalog;
   }
 
   /**

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -84,6 +84,8 @@ final class PooledConnection extends ConnectionDelegator {
   private boolean resetAutoCommit;
   private boolean resetSchema;
   private boolean resetCatalog;
+  private boolean initialisedSchema;
+  private boolean initialisedCatalog;
   private String currentSchema;
   private String currentCatalog;
   private String originalSchema;
@@ -120,6 +122,8 @@ final class PooledConnection extends ConnectionDelegator {
     this.name = pool.name() + uniqueId;
     this.originalSchema = pool.schema();
     this.originalCatalog = pool.catalog();
+    this.initialisedSchema = originalSchema != null;
+    this.initialisedCatalog = originalCatalog != null;
     this.pstmtCache = new PstmtCache(pool.pstmtCacheSize());
     this.maxStackTrace = pool.maxStackTraceSize();
     this.creationTime = System.currentTimeMillis();
@@ -700,9 +704,10 @@ final class PooledConnection extends ConnectionDelegator {
     if (status == STATUS_IDLE) {
       throw new SQLException(IDLE_CONNECTION_ACCESSED_ERROR + "setSchema()");
     }
-    if (originalSchema == null) {
+    if (!initialisedSchema) {
       // lazily initialise the originalSchema
       originalSchema = getSchema();
+      initialisedSchema = true;
     }
     currentSchema = schema;
     resetSchema = true;
@@ -714,9 +719,9 @@ final class PooledConnection extends ConnectionDelegator {
     if (status == STATUS_IDLE) {
       throw new SQLException(IDLE_CONNECTION_ACCESSED_ERROR + "setCatalog()");
     }
-    if (originalCatalog == null) {
-      // lazily initialise the originalCatalog
+    if (!initialisedCatalog) {
       originalCatalog = getCatalog();
+      initialisedCatalog = true;
     }
     currentCatalog = catalog;
     resetCatalog = true;

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -385,21 +385,12 @@ final class PooledConnection extends ConnectionDelegator {
    * Reset the connection for returning to the client. Resets the status,
    * startUseTime and hadErrors.
    */
-  void resetForUse() throws SQLException {
+  void resetForUse() {
     this.status = STATUS_ACTIVE;
     this.startUseTime = System.currentTimeMillis();
     this.createdByMethod = null;
     this.lastStatement = null;
     this.hadErrors = false;
-    // CHECKME: Shoud we keep the asserts here or should we even reset schema/catalog here
-    assert schemaState != SCHEMA_CATALOG_CHANGED : "connection is in the wrong state (not properly closed)";
-    if (schemaState == SCHEMA_CATALOG_KNOWN) {
-      assert originalSchema.equals(getSchema()) : "connection is in the wrong schema: " + getSchema() + ", expected: " + originalSchema;
-    }
-    assert catalogState != SCHEMA_CATALOG_CHANGED : "connection is in the wrong state (not properly closed)";
-    if (catalogState == SCHEMA_CATALOG_KNOWN) {
-      assert originalCatalog.equals(getCatalog()) : "connection is in the wrong catalog: " + getCatalog() + ", expected: " + originalCatalog;
-    }
   }
 
   /**

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -124,6 +124,8 @@ final class PooledConnection extends ConnectionDelegator {
     this.originalCatalog = pool.catalog();
     this.initialisedSchema = originalSchema != null;
     this.initialisedCatalog = originalCatalog != null;
+    this.currentSchema = originalSchema != null ? originalSchema : "@default";
+    this.currentCatalog = originalCatalog != null ? originalCatalog : "@default";
     this.pstmtCache = new PstmtCache(pool.pstmtCacheSize());
     this.maxStackTrace = pool.maxStackTraceSize();
     this.creationTime = System.currentTimeMillis();

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -422,11 +422,13 @@ final class PooledConnection extends ConnectionDelegator {
 
       if (resetSchema) {
         connection.setSchema(originalSchema);
+        currentSchema = null;
         resetSchema = false;
       }
 
       if (resetCatalog) {
         connection.setCatalog(originalCatalog);
+        currentCatalog = null;
         resetCatalog = false;
       }
 

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/PostgresInitTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/PostgresInitTest.java
@@ -81,7 +81,7 @@ class PostgresInitTest {
   void test_with_applicationNameAndSchema() throws SQLException {
     DataSourceConfig ds = new DataSourceConfig();
     ds.setUrl("jdbc:postgresql://127.0.0.1:9999/app");
-    ds.setSchema("fred");
+    ds.setSchema("public");
     ds.setUsername("db_owner");
     ds.setPassword("test");
     ds.setApplicationName("my-application-name");
@@ -112,7 +112,7 @@ class PostgresInitTest {
   void test_password2() throws SQLException {
     DataSourceConfig ds = new DataSourceConfig();
     ds.setUrl("jdbc:postgresql://127.0.0.1:9999/app");
-    ds.setSchema("fred");
+    ds.setSchema("public");
     ds.setUsername("db_owner");
     ds.setPassword("test");
     ds.setPassword2("newRolledPassword");


### PR DESCRIPTION
- Make originalSchema and originalCatalog non final and default from the pool configuration
- Initialise originalSchema and originalCatalog lazily if required and when they are not set from the pool configuration

This improves the performance of initialising connections for the cases where schema and catalog are not changed, by skipping the reading of the schema and catalog from the connection [which is frequently a query/network call].

@rPraml, can I get you to review this.

Note: The currentSchema is null when using the originalSchema, I think this is ok (with key for cached PreparedStatements etc). 