### PR TITLE
Fix leaking connections when it was not possible to close them.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         java-version: ${{ matrix.java_version }}
         distribution: 'zulu'
     - name: Maven cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: maven-cache
       with:

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -751,25 +751,24 @@ public interface DataSourceBuilder {
 
 
   /**
-   * Sets the behaviour what to do, when a connection is closed (=returned to pool), while there is uncommitted work.
+   * When enabled, the datasource enforces a clean close. This means, if you close a possible dirty
+   * connection, that was not committed or rolled back, an exception is thrown.
    * <p>
-   * Possible values
-   * <ul>
-   *   <li><code>nothing</code> nothing happens</li>
-   *   <li><code>rollback</code> a rollback is performed (default)</li>
-   *   <li><code>commit</code> a commit is performed (dangerous!)</li>
-   *   <li><code>remove</code> the connection is removed from the pool (not recommended for production, connection might leak)</li>
-   *   <li><code>fail</code> an exception is thrown by close itself (for debugging, not recommended for production)</li>
-   * </ul>
+   * When disabled, the situation is logged as warning.
+   * <p>
+   * This option has no effect on readonly or autocommit connections.
+   * <p>
+   * Note: It is recommended to enable this option in tests/test systems to find possible
+   * programming errors. See https://github.com/ebean-orm/ebean-datasource/issues/116 for details.
    */
-  DataSourceBuilder closeWithinTxn(String closeWithinTxn);
+  DataSourceBuilder enforceCleanClose(boolean enforceCleanClose);
 
   /**
-   * Returns the behaviour, what to do, when a connection is (=returned to pool), while there is uncommitted work.
+   * When <code>true</code>, an exception is thrown when a dirty connection is closed.
    * <p>
-   * See {@link #closeWithinTxn(String)}.
+   * See {@link #enforceCleanClose(boolean)}.
    */
-  String closeWithinTxn();
+  boolean enforceCleanClose();
 
   /**
    * The settings of the DataSourceBuilder. Provides getters/accessors

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -749,6 +749,28 @@ public interface DataSourceBuilder {
    */
   DataSourceBuilder loadSettings(Properties properties, String poolName);
 
+
+  /**
+   * Sets the behaviour what to do, when a connection is closed (=returned to pool), while there is uncommitted work.
+   * <p>
+   * Possible values
+   * <ul>
+   *   <li><code>nothing</code> nothing happens</li>
+   *   <li><code>rollback</code> a rollback is performed (default)</li>
+   *   <li><code>commit</code> a commit is performed (dangerous!)</li>
+   *   <li><code>remove</code> the connection is removed from the pool (not recommended for production, connection might leak)</li>
+   *   <li><code>fail</code> an exception is thrown by close itself (for debugging, not recommended for production)</li>
+   * </ul>
+   */
+  DataSourceBuilder closeWithinTxn(String closeWithinTxn);
+
+  /**
+   * Returns the behaviour, what to do, when a connection is (=returned to pool), while there is uncommitted work.
+   * <p>
+   * See {@link #closeWithinTxn(String)}.
+   */
+  String closeWithinTxn();
+
   /**
    * The settings of the DataSourceBuilder. Provides getters/accessors
    * to read the configured properties of this DataSourceBuilder.

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -83,7 +83,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private String applicationName;
   private boolean shutdownOnJvmExit;
   private boolean validateOnHeartbeat = !System.getenv().containsKey("LAMBDA_TASK_ROOT");
-  private String closeWithinTxn = "rollback";
+  private boolean enforceCleanClose;
 
   @Override
   public Settings settings() {
@@ -145,7 +145,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     copy.initSql = initSql;
     copy.alert = alert;
     copy.listener = listener;
-    copy.closeWithinTxn = closeWithinTxn;
+    copy.enforceCleanClose = enforceCleanClose;
     return copy;
   }
 
@@ -800,7 +800,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     offline = properties.getBoolean("offline", offline);
     shutdownOnJvmExit = properties.getBoolean("shutdownOnJvmExit", shutdownOnJvmExit);
     validateOnHeartbeat = properties.getBoolean("validateOnHeartbeat", validateOnHeartbeat);
-    closeWithinTxn = properties.get("closeWithinTxn", closeWithinTxn);
+    enforceCleanClose = properties.getBoolean("enforceCleanClose", enforceCleanClose);
 
 
     String isoLevel = properties.get("isolationLevel", _isolationLevel(isolationLevel));
@@ -851,14 +851,14 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   }
 
   @Override
-  public DataSourceBuilder closeWithinTxn(String closeWithinTxn) {
-    this.closeWithinTxn = closeWithinTxn;
+  public DataSourceBuilder enforceCleanClose(boolean enforceCleanClose) {
+    this.enforceCleanClose = enforceCleanClose;
     return this;
   }
 
   @Override
-  public String closeWithinTxn() {
-    return closeWithinTxn;
+  public boolean enforceCleanClose() {
+    return enforceCleanClose;
   }
 
   /**

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -83,6 +83,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private String applicationName;
   private boolean shutdownOnJvmExit;
   private boolean validateOnHeartbeat = !System.getenv().containsKey("LAMBDA_TASK_ROOT");
+  private String closeWithinTxn = "rollback";
 
   @Override
   public Settings settings() {
@@ -144,6 +145,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     copy.initSql = initSql;
     copy.alert = alert;
     copy.listener = listener;
+    copy.closeWithinTxn = closeWithinTxn;
     return copy;
   }
 
@@ -798,6 +800,8 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     offline = properties.getBoolean("offline", offline);
     shutdownOnJvmExit = properties.getBoolean("shutdownOnJvmExit", shutdownOnJvmExit);
     validateOnHeartbeat = properties.getBoolean("validateOnHeartbeat", validateOnHeartbeat);
+    closeWithinTxn = properties.get("closeWithinTxn", closeWithinTxn);
+
 
     String isoLevel = properties.get("isolationLevel", _isolationLevel(isolationLevel));
     this.isolationLevel = _isolationLevel(isoLevel);
@@ -844,6 +848,17 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
       }
     }
     return propertyMap;
+  }
+
+  @Override
+  public DataSourceBuilder closeWithinTxn(String closeWithinTxn) {
+    this.closeWithinTxn = closeWithinTxn;
+    return this;
+  }
+
+  @Override
+  public String closeWithinTxn() {
+    return closeWithinTxn;
   }
 
   /**

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourcePoolListener.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourcePoolListener.java
@@ -17,11 +17,12 @@ public interface DataSourcePoolListener {
   /**
    * Called after a connection has been retrieved from the connection pool
    */
-  void onAfterBorrowConnection(Connection connection);
+  default void onAfterBorrowConnection(Connection connection) {}
 
   /**
    * Called before a connection will be put back to the connection pool
    */
-  void onBeforeReturnConnection(Connection connection);
+  default void onBeforeReturnConnection(Connection connection) {}
+
 
 }

--- a/ebean-datasource/pom.xml
+++ b/ebean-datasource/pom.xml
@@ -76,6 +76,13 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.ibm.db2</groupId>
+      <artifactId>jcc</artifactId>
+      <version>11.5.9.0</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -95,7 +95,6 @@ final class ConnectionPool implements DataSourcePool {
   private final boolean shutdownOnJvmExit;
   private Thread shutdownHook;
 
-
   ConnectionPool(String name, DataSourceConfig params) {
     this.config = params;
     this.name = name;
@@ -135,7 +134,6 @@ final class ConnectionPool implements DataSourcePool {
       init();
     }
     this.nextTrimTime = System.currentTimeMillis() + trimPoolFreqMillis;
-
   }
 
   private void init() {

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -219,7 +219,7 @@ final class PooledConnection extends ConnectionDelegator {
   }
 
   String fullDescription() {
-    return "name[" + name + "] startTime[" + startUseTime() + "] busySeconds[" + busySeconds() + "] stackTrace[" + stackTraceAsString() + "] stmt[" + lastStatement() + "]";
+    return "name[" + name + "] startTime[" + startUseTime() + "] busySeconds[" + busySeconds() + "] stackTrace[" + stackTraceAsString(stackTrace) + "] stmt[" + lastStatement() + "]";
   }
 
   /**
@@ -449,9 +449,9 @@ final class PooledConnection extends ConnectionDelegator {
       throw new SQLException(IDLE_CONNECTION_ACCESSED_ERROR + "close()");
     }
     boolean mayHaveUncommittedChanges = !autoCommit && !readOnly && status == STATUS_ACTIVE;
-    if (mayHaveUncommittedChanges && pool.failIfWithinTransaction()) {
+    if (mayHaveUncommittedChanges && pool.enforceCleanClose()) {
       pool.returnConnectionForceClose(this);
-      throw new SQLException("Tried to close active connection within transaction");
+      throw new AssertionError("Tried to close a dirty connection. See https://github.com/ebean-orm/ebean-datasource/issues/116 for details.");
     }
     if (hadErrors) {
       if (failoverToReadOnly) {
@@ -469,7 +469,9 @@ final class PooledConnection extends ConnectionDelegator {
         return;
       }
       if (mayHaveUncommittedChanges) {
-        pool.closeWithinTxn(this);
+        Log.warn("Tried to close a dirty connection at {0}. See https://github.com/ebean-orm/ebean-datasource/issues/116 for details.",
+          stackTraceAsString(Thread.currentThread().getStackTrace()));
+        connection.rollback();
       }
       // reset the autoCommit back if client code changed it
       if (autoCommit != pool.isAutoCommit()) {
@@ -949,35 +951,23 @@ final class PooledConnection extends ConnectionDelegator {
   /**
    * Return the stackTrace as a String for logging purposes.
    */
-  private String stackTraceAsString() {
-    StackTraceElement[] stackTrace = stackTrace();
+  private String stackTraceAsString(StackTraceElement[] stackTrace) {
     if (stackTrace == null) {
       return "";
-    }
-    return Arrays.toString(stackTrace);
-  }
-
-  /**
-   * Return the full stack trace that got the connection from the pool. You
-   * could use this if getCreatedByMethod() doesn't work for you.
-   */
-  private StackTraceElement[] stackTrace() {
-    if (stackTrace == null) {
-      return null;
     }
 
     // filter off the top of the stack that we are not interested in
     ArrayList<StackTraceElement> filteredList = new ArrayList<>();
     boolean include = false;
     for (StackTraceElement stackTraceElement : stackTrace) {
-      if (!include && includeMethodLine(stackTraceElement.toString())) {
+      if (!include && includeMethodLine(stackTraceElement.getClassName())) {
         include = true;
       }
       if (include && filteredList.size() < maxStackTrace) {
         filteredList.add(stackTraceElement);
       }
     }
-    return filteredList.toArray(new StackTraceElement[0]);
+    return filteredList.toString();
   }
 
 }

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -463,6 +463,7 @@ final class PooledConnection extends ConnectionDelegator {
         return;
       }
     }
+
     try {
       if (connection.isClosed()) {
         pool.removeClosedConnection(this);

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolCloseTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolCloseTest.java
@@ -1,0 +1,175 @@
+package io.ebean.datasource.pool;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.ebean.datasource.DataSourceBuilder;
+import io.ebean.datasource.DataSourcePool;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLSyntaxErrorException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests, if connections are clean when closing them.
+ * <p>
+ * Test must run with "do not use module path" option in IntelliJ.
+ * <p>
+ * See also https://github.com/ebean-orm/ebean-datasource/issues/116 for more details
+ */
+class ConnectionPoolCloseTest {
+
+  private static ListAppender<ILoggingEvent> logCapture = new ListAppender<>();
+
+  private static DataSourcePool pool = createPool(false, false);
+  private static DataSourcePool poolRo = createPool(false, true);
+  private static DataSourcePool poolEnforce = createPool(true, false);
+  private static DataSourcePool poolEnforceRo = createPool(true, true);
+
+
+  @BeforeAll
+  static void before() {
+    // attach logback appender to capture log messages
+    ((ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.ebean.datasource")).addAppender(logCapture);
+    logCapture.start();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    logCapture.list.clear();
+  }
+
+  @AfterAll
+  static void after() {
+    logCapture.stop();
+    pool.shutdown();
+    poolRo.shutdown();
+    poolEnforce.shutdown();
+    poolEnforceRo.shutdown();
+  }
+
+  @Test
+  void testNoCommitOrRollback() throws SQLException {
+
+    doNoCommitOrRollback(pool);
+    assertThat(getAndResetLogWarinings())
+      .hasSize(1)
+      .first().asString().startsWith("[WARN] Tried to close a dirty connection at");
+
+    assertThatThrownBy(() -> doNoCommitOrRollback(poolEnforce)).isInstanceOf(AssertionError.class);
+
+    doNoCommitOrRollback(poolRo);
+    assertThat(getAndResetLogWarinings()).isEmpty();
+
+    doNoCommitOrRollback(poolEnforceRo);
+    assertThat(getAndResetLogWarinings()).isEmpty();
+
+  }
+
+  @Test
+  void testCommit() throws SQLException {
+    doCommit(pool);
+    doCommit(poolRo);
+    doCommit(poolEnforce);
+    doCommit(poolEnforceRo);
+    assertThat(getAndResetLogWarinings()).isEmpty();
+  }
+
+  @Test
+  void testRollback() throws SQLException {
+    doRollback(pool);
+    doRollback(poolRo);
+    doRollback(poolEnforce);
+    doRollback(poolEnforceRo);
+    assertThat(getAndResetLogWarinings()).isEmpty();
+  }
+
+  @Test
+  void testExecuteValidSql() throws SQLException {
+    doExecute(pool, "SELECT 1");
+    doExecute(poolRo, "SELECT 1");
+    doExecute(poolEnforce, "SELECT 1");
+    doExecute(poolEnforceRo, "SELECT 1");
+    assertThat(getAndResetLogWarinings()).isEmpty();
+  }
+
+  @Test
+  void testExecuteInvalidSql() throws SQLException {
+    assertThatThrownBy(() -> doExecute(pool, "invalid query"))
+      .isInstanceOf(SQLSyntaxErrorException.class)
+      .hasNoSuppressedExceptions();
+    // (un)fortunately, we will log a missing rollback, when exception in try-with-resourches is thrown.
+    assertThat(getAndResetLogWarinings())
+      .hasSize(1)
+      .first().asString().startsWith("[WARN] Tried to close a dirty connection at");
+
+    assertThatThrownBy(() -> doExecute(poolEnforce, "invalid query"))
+      .isInstanceOf(SQLSyntaxErrorException.class)
+      .hasSuppressedException(new AssertionError("Tried to close a dirty connection. See https://github.com/ebean-orm/ebean-datasource/issues/116 for details."));
+
+    assertThatThrownBy(() -> doExecute(poolRo, "invalid query"))
+      .isInstanceOf(SQLSyntaxErrorException.class)
+      .hasNoSuppressedExceptions();
+
+    assertThatThrownBy(() -> doExecute(poolEnforceRo, "invalid query"))
+      .isInstanceOf(SQLSyntaxErrorException.class)
+      .hasNoSuppressedExceptions();
+    assertThat(getAndResetLogWarinings()).isEmpty();
+  }
+
+  private static void doNoCommitOrRollback(DataSourcePool pool) throws SQLException {
+    try (Connection connection = pool.getConnection()) {
+      // we do nothing here.
+    }
+  }
+
+  private static void doCommit(DataSourcePool pool) throws SQLException {
+    try (Connection connection = pool.getConnection()) {
+      connection.commit();
+    }
+  }
+
+  private static void doRollback(DataSourcePool pool) throws SQLException {
+    try (Connection connection = pool.getConnection()) {
+      connection.rollback();
+    }
+  }
+
+  private static void doExecute(DataSourcePool pool, String query) throws SQLException {
+    try (Connection connection = pool.getConnection()) {
+      connection.createStatement().execute(query);
+      connection.commit();
+    }
+  }
+
+  private static List<ILoggingEvent> getAndResetLogWarinings() {
+    List<ILoggingEvent> warnings = logCapture.list.stream().filter(e -> e.getLevel().levelInt >= Level.WARN_INT).collect(Collectors.toList());
+    logCapture.list.clear();
+    return warnings;
+  }
+
+  private static DataSourcePool createPool(boolean enforceCleanClose, boolean readOnly) {
+    DataSourcePool ret = DataSourceBuilder.create()
+      .url("jdbc:h2:mem:tests")
+      .username("sa")
+      .password("")
+      .minConnections(2)
+      .maxConnections(4)
+      .enforceCleanClose(enforceCleanClose)
+      .readOnly(readOnly)
+      .build();
+    // clear capturer after create
+    logCapture.list.clear();
+    return ret;
+  }
+}

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/Db2Test.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/Db2Test.java
@@ -1,0 +1,207 @@
+package io.ebean.datasource.test;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.ibm.db2.jcc.DB2Connection;
+import io.avaje.applog.AppLog;
+import io.ebean.datasource.DataSourceBuilder;
+import io.ebean.datasource.DataSourcePool;
+import io.ebean.datasource.DataSourcePoolListener;
+import io.ebean.test.containers.Db2Container;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * DB2 has a strange behaviour, when a connection is in a dirty state and neither committed nor rolled back.
+ * <p>
+ * By default, a transaction cannot be closed if it is in an unit of work and an exception is thrown.
+ * <p>
+ * This can be controlled with the "connectionCloseWithInFlightTransaction" parameter
+ * https://www.ibm.com/docs/en/db2/11.5?topic=pdsdjs-common-data-server-driver-jdbc-sqlj-properties-all-database-products
+ * <p>
+ * There are several cases, when there is an open unit of work:
+ * <ul>
+ *   <li>forget commit/rollback before closing the connection, because an exception occurs</li>
+ *   <li>calling connection.getSchema() starts a new UOW (because it internally executes a query)</li>
+ * </ul>
+ */
+class Db2Test {
+
+	private static Db2Container container;
+
+	private static ListAppender<ILoggingEvent> logCapture = new ListAppender<>();
+
+	@BeforeAll
+	static void before() {
+		container = Db2Container.builder("11.5.6.0a")
+				.dbName("unit")
+				.user("unit")
+				.password("unit")
+				// to change collation, charset and other parameters like pagesize:
+				.configOptions("USING CODESET UTF-8 TERRITORY DE COLLATE USING IDENTITY PAGESIZE 32768")
+				.configOptions("USING STRING_UNITS CODEUNITS32")
+				.build();
+
+		// container.startWithDropCreate();
+		container.start();
+
+		// attach logback appender to capture log messages
+		((ch.qos.logback.classic.Logger) LoggerFactory.getLogger("io.ebean.datasource")).addAppender(logCapture);
+		logCapture.start();
+	}
+
+	@AfterAll
+	static void after() {
+		//   container.stopRemove();
+		logCapture.stop();
+	}
+
+	@Test
+	void testNoCommitOrRollback() throws SQLException {
+
+		DataSourcePool pool = getPool();
+
+		logCapture.list.clear();
+		try {
+			try (Connection connection = pool.getConnection()) {
+				// we do nothing here.
+			}
+		} finally {
+			pool.shutdown();
+		}
+		assertThat(logCapture.list.stream().filter(e -> e.getLevel().levelInt >= Level.WARN_INT)).isEmpty();
+		assertThat(logCapture.list)
+				.extracting(ILoggingEvent::toString).contains("[TRACE] Closing active connection. Rollback performed.");
+	}
+
+
+	@Test
+	void testFalseFriendRollback() throws SQLException {
+
+		DataSourcePool pool = getPool();
+
+		logCapture.list.clear();
+		try {
+			try (Connection connection = pool.getConnection()) {
+				// we do a rollback here
+				connection.rollback();
+				connection.getSchema(); // will re-open a new UOW
+			}
+		} finally {
+			pool.shutdown();
+		}
+
+		assertThat(logCapture.list.stream().filter(e -> e.getLevel().levelInt >= Level.WARN_INT))
+				.extracting(ILoggingEvent::toString).containsExactly("[WARN] There is a DB2 UOW open!");
+		assertThat(logCapture.list)
+				.extracting(ILoggingEvent::toString).doesNotContain("[TRACE] Closing active connection. Rollback performed.");
+	}
+
+	@Test
+	void testProperUse() throws SQLException {
+
+		DataSourcePool pool = getPool();
+
+		logCapture.list.clear();
+		try {
+			try (Connection connection = pool.getConnection()) {
+				connection.commit();
+			}
+		} finally {
+			pool.shutdown();
+		}
+
+		assertThat(logCapture.list.stream().filter(e -> e.getLevel().levelInt >= Level.WARN_INT)).isEmpty();
+		assertThat(logCapture.list)
+				.extracting(ILoggingEvent::toString).doesNotContain("[TRACE] Closing active connection. Rollback performed.");
+
+	}
+
+	@Test
+	void testErrorOccured() throws SQLException {
+
+		DataSourcePool pool = getPool();
+
+		logCapture.list.clear();
+		try {
+			try (Connection connection = pool.getConnection()) {
+				try (PreparedStatement statement = connection.prepareStatement("i am invalid")) {
+					statement.execute();
+				}
+				connection.commit(); // we will not get here
+			} catch (SQLException e) {
+				// expected
+			}
+		} finally {
+			pool.shutdown();
+		}
+
+		assertThat(logCapture.list.stream().filter(e -> e.getLevel().levelInt >= Level.WARN_INT)).isEmpty();
+		assertThat(logCapture.list)
+				.extracting(ILoggingEvent::toString).contains("[TRACE] Closing active connection. Rollback performed.");
+	}
+
+
+	@Test
+	void testProperShutdownWithMissingListener() throws SQLException {
+
+		DataSourcePool pool = DataSourceBuilder.create()
+				.url(container.jdbcUrl())
+				.username("unit")
+				.password("unit")
+				.ownerUsername("unit")
+				.ownerPassword("unit")
+				.closeWithinTxn("rollback")
+				.build();
+
+		logCapture.list.clear();
+		try {
+			try (Connection connection = pool.getConnection()) {
+				// we do a rollback here
+				connection.rollback();
+				connection.getSchema();
+			}
+		} finally {
+			pool.shutdown();
+		}
+
+		assertThat(logCapture.list.stream().filter(e -> e.getLevel().levelInt >= Level.WARN_INT)).isEmpty();
+		assertThat(logCapture.list)
+				.extracting(ILoggingEvent::toString).doesNotContain("[TRACE] Closing active connection. Rollback performed.");
+
+	}
+
+	private static DataSourcePool getPool() {
+		return DataSourceBuilder.create()
+				.url(container.jdbcUrl())
+				.username("unit")
+				.password("unit")
+				.ownerUsername("unit")
+				.ownerPassword("unit")
+				.closeWithinTxn("rollback")
+				.listener(new DataSourcePoolListener() {
+					@Override
+					public void onBeforeReturnConnection(Connection connection) {
+						try {
+							DB2Connection db2conn = connection.unwrap(DB2Connection.class);
+							if (db2conn.isInDB2UnitOfWork()) {
+								AppLog.getLogger("io.ebean.datasource").log(System.Logger.Level.WARNING, "There is a DB2 UOW open!");
+								db2conn.rollback();
+							}
+						} catch (SQLException e) {
+							throw new RuntimeException(e);
+						}
+					}
+				})
+				.build();
+	}
+}


### PR DESCRIPTION
DB2 has a problem, that it won't allow to close connections if there is an uncommitted UOW.

This PR adresses the following issues:

1. When an active connection is returned to the pool. e.g. by this code block
```java
      try (Connection connection = pool.getConnection()) {
        // we do nothing here.
      }
```
a warning is logged, that commit/rollback was missing. We also try to roll back this connection, as in the worst case, data can leak to the next usage.

This is done here: https://github.com/ebean-orm/ebean-datasource/compare/master...FOCONIS:ebean-datasource:db2-tests?expand=1#diff-916f1a5da1ef6f478d7cb23223fc9bfd2fb0c64ff6b0484f399c19403c6ddb8fR457

2. When shutting down the pool, we always try to roll back the connection first, before it will be closed. If this is not done, DB2 will not close the transaction, if there is still UOW open. This can happen, as various commands like `getSchema` can start a new UOW an already committed/rollbacked connection. The connection will be never closed and the tcp/ip connection kept open until the JVM will restart
See test `testFalseFriendRollback`

3. We changed the invocation of `DataSourcePoolListener.onBeforeReturnConnection` to the beginning of the whole reset process of autocommit/isolationLevel/catalog/schema/status=IDLE.
This allows us to install a custom DB2-listener. While 1 + 2 will cover 95% of leaking connections, the listener can check `isInDB2UnitOfWork` and handle the other 5%.

This might be considered as behaviour change, if you think, `onBeforeReturnConnection` should be the last method, I can add a `onBeforeResetConnection` to the listener.


I know, the behaviour of DB2-JCC driver is a bit odd here (and could theoretically be configured with `connectionCloseWithInFlightTransaction` parameter) - but it is as it is. And we had major outages last week.

@rbygrave It would be great, if we get feedback about these changes

/edit: What happened exactly:

This change https://github.com/ebean-orm/ebean-datasource/commit/94f9f71b7ef03202b31c4001f0070ea2b6b94789#diff-916f1a5da1ef6f478d7cb23223fc9bfd2fb0c64ff6b0484f399c19403c6ddb8fR125 caused the trouble.

- If the system was under the correct load, so that for the heartbeat thread a newly created connection was issued, the getSchema caused, that this connection had an "open UOW".
- Now the "testConnection" just verifies, if this connection is OK, performs neither a commit, nor a rollback and put this connection back on the pool
- Now we have an "uncloseable" connection in the pool. If this connection gets trimmed/closed, an error is detected and the connection was removed from the pool, but keeps the tcp/ip connection open until server restart.

The change to `getSchema()` in the initialization (which is already removed in 9.2) makes this scenario more likely.

So now, we have either improved the close logic (to try a rollback) and also do a rollback in the heartbeat

https://github.com/ebean-orm/ebean-datasource/pull/107/files#diff-17a97b637b84f5d3e16f487dcd4a8d80d7cdb9f165b528cdc4d495cc93070647R380

Note: The JDBC-documentation says https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#close--

> It is **strongly recommended** that an application explicitly commits or rolls back an active transaction prior to calling the close method. If the close method is called and there is an active transaction, the results are implementation-defined. 

So I think, we can enforce this behaviour. I also think we may throw an exception instead of the Log.trace

