### PR TITLE
Always close or rollback connection to avoid possible leak

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -377,6 +377,9 @@ final class ConnectionPool implements DataSourcePool {
     } finally {
       try {
         if (conn != null) {
+          if (!conn.getAutoCommit()) {
+            conn.rollback();
+          }
           conn.close();
         }
       } catch (SQLException ex) {

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolOfflineTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolOfflineTest.java
@@ -113,6 +113,7 @@ public class ConnectionPoolOfflineTest implements WaitFor {
         try (PreparedStatement statement = busy.prepareStatement("select 'hello' from dual")) {
           statement.execute();
         }
+        busy.commit();
         Thread.sleep(3000);
         System.out.println("busy connection closing now");
         busy.close();
@@ -155,6 +156,7 @@ public class ConnectionPoolOfflineTest implements WaitFor {
     try (Connection connection = pool.getConnection()) {
       assertThat(connection).isNotNull();
       assertThat(pool.isOnline()).isTrue();
+      connection.rollback();
     }
 
     pool.shutdown();

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolSpeedTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolSpeedTest.java
@@ -35,6 +35,7 @@ public class ConnectionPoolSpeedTest {
     config.setPassword("");
     config.setMinConnections(2);
     config.setMaxConnections(100);
+    config.setAutoCommit(true);
 
     return new ConnectionPool("testspeed", config);
   }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTest.java
@@ -50,16 +50,19 @@ class ConnectionPoolTest {
     assertThat(pool.status(false).free()).isEqualTo(0);
     assertThat(pool.size()).isEqualTo(3);
 
+    con2.rollback();
     con2.close();
     assertThat(pool.status(false).busy()).isEqualTo(2);
     assertThat(pool.status(false).free()).isEqualTo(1);
     assertThat(pool.size()).isEqualTo(3);
 
+    con3.rollback();
     con3.close();
     assertThat(pool.status(false).busy()).isEqualTo(1);
     assertThat(pool.status(false).free()).isEqualTo(2);
     assertThat(pool.size()).isEqualTo(3);
 
+    con1.rollback();
     con1.close();
     assertThat(pool.status(false).busy()).isEqualTo(0);
     assertThat(pool.status(false).free()).isEqualTo(3);
@@ -72,6 +75,7 @@ class ConnectionPoolTest {
     PreparedStatement statement = connection.prepareStatement("create user testing password '123'");
     statement.execute();
     statement.close();
+    connection.rollback();
     connection.close();
 
     Connection another = pool.getConnection("testing", "123");
@@ -79,12 +83,14 @@ class ConnectionPoolTest {
 
     for (int i = 0; i < 10_000; i++) {
       Connection another2 = pool.getConnection();
+      another2.rollback();
       another2.close();
     }
     PoolStatus status0 = pool.status(true);
 
     for (int i = 0; i < 10_000; i++) {
       Connection another2 = pool.getConnection();
+      another2.rollback();
       another2.close();
     }
     PoolStatus status = pool.status(false);
@@ -100,6 +106,7 @@ class ConnectionPoolTest {
     Connection underlying = connection.unwrap(Connection.class);
 
     assertThat(underlying).isInstanceOf(org.h2.jdbc.JdbcConnection.class);
+    connection.rollback();
     connection.close();
   }
 
@@ -110,6 +117,7 @@ class ConnectionPoolTest {
     Connection underlying = pc.delegate();
 
     assertThat(underlying).isInstanceOf(org.h2.jdbc.JdbcConnection.class);
+    connection.rollback();
     connection.close();
   }
 
@@ -118,6 +126,7 @@ class ConnectionPoolTest {
     Connection connection = pool.getConnection();
     assertThat(connection.isClosed()).isFalse();
 
+    connection.rollback();
     connection.close();
     assertThat(connection.isClosed()).isTrue();
   }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTrimIdleTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTrimIdleTest.java
@@ -40,9 +40,13 @@ public class ConnectionPoolTrimIdleTest implements WaitFor {
       Connection con4 = pool.getConnection();
       assertThat(pool.size()).isEqualTo(4);
 
+      con1.rollback();
       con1.close();
+      con2.rollback();
       con2.close();
+      con3.rollback();
       con3.close();
+      con4.rollback();
       con4.close();
       assertThat(pool.size()).isEqualTo(4);
       assertThat(pool.status(false).free()).isEqualTo(4);
@@ -67,6 +71,7 @@ public class ConnectionPoolTrimIdleTest implements WaitFor {
         con[i] = pool.getConnection();
       }
       for (int i = 0; i < 10; i++) {
+        con[i].rollback();
         con[i].close();
       }
 
@@ -125,6 +130,7 @@ public class ConnectionPoolTrimIdleTest implements WaitFor {
           connection[i] = pool.getConnection();
         }
         for (int i = 0; i < count; i++) {
+          connection[i].rollback();
           connection[i].close();
         }
 

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/DataSourcePoolFactoryTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/DataSourcePoolFactoryTest.java
@@ -54,6 +54,7 @@ class DataSourcePoolFactoryTest {
     for (int i = 0; i < 10; i++) {
       try (Connection connection = pool.getConnection()) {
         connection.hashCode();
+        connection.rollback();
       }
     }
 

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ExtendedPreparedStatementTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ExtendedPreparedStatementTest.java
@@ -34,6 +34,7 @@ public class ExtendedPreparedStatementTest {
 				// this is an extra call to close()
 				stmt.close();
 			}
+      connection.rollback();
 		}
 	}
 }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/SchemaTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/SchemaTest.java
@@ -67,6 +67,7 @@ class SchemaTest {
       ResultSet rs = statement.executeQuery("SELECT name FROM test");
       assertThat(rs.next()).isTrue();
       assertThat(rs.getString("name")).isEqualTo("default schema");
+      conn.rollback();
     }
     try (Connection conn = pool.getConnection()) {
       conn.setSchema("SCHEMA1");
@@ -74,6 +75,7 @@ class SchemaTest {
       ResultSet rs = statement.executeQuery("SELECT name FROM test");
       assertThat(rs.next()).isTrue();
       assertThat(rs.getString("name")).isEqualTo("schema1");
+      conn.rollback();
     }
     try (Connection conn = pool.getConnection()) {
       conn.setSchema("SCHEMA2");
@@ -81,12 +83,14 @@ class SchemaTest {
       ResultSet rs = statement.executeQuery("SELECT name FROM test");
       assertThat(rs.next()).isTrue();
       assertThat(rs.getString("name")).isEqualTo("schema2");
+      conn.rollback();
     }
     try (Connection conn = pool.getConnection()) {
       Statement statement = conn.createStatement();
       ResultSet rs = statement.executeQuery("SELECT name FROM test");
       assertThat(rs.next()).isTrue();
       assertThat(rs.getString("name")).isEqualTo("default schema");
+      conn.rollback();
     }
   }
 }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/FactoryTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/FactoryTest.java
@@ -208,6 +208,7 @@ class FactoryTest {
       } catch (SQLException e) {
         // expected: Parameter "#1" not set
       }
+      connection.rollback();
     }
   }
 }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/PostgresInitTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/PostgresInitTest.java
@@ -139,8 +139,11 @@ class PostgresInitTest {
             testConnectionWithSelect(newConnection0, "select acol from app.my_table2");
             try (Connection newConnection1 = pool.getConnection()) {
               testConnectionWithSelect(newConnection1, "select acol from app.my_table2");
+              newConnection1.rollback();
             }
+            newConnection0.rollback();
           }
+          connection1.rollback();
         }
 
         // a new pool switches immediately
@@ -151,8 +154,11 @@ class PostgresInitTest {
             testConnectionWithSelect(connP2_1, "select acol from app.my_table2");
             try (var connP2_2 = pool2.getConnection()) {
               testConnectionWithSelect(connP2_2, "select acol from app.my_table2");
+              connP2_2.rollback();
             }
+            connP2_1.rollback();
           }
+          connP2_0.rollback();
         }
 
         // reset the password back for other tests


### PR DESCRIPTION
@rbygrave This is a part of #107 and it would be great, if this can get merged soon.

what have we done here:

in #107 I've added a mode `CloseWithinTxn.FAIL` that complains, if you call `close` without a previous commit or rollback.

The ConnectionPool behaves in this mode very similar as the DB2JCC driver. The driver does not allow `close` within an UOW (UnitOfWork, =Transaction).
As reported in #107, a `getSchema()` can cause to start a UOW. so just a `try-with-resources` will not work any longer.

In this PR, I added commits or rollbacks in the tests, so that it will follow the JDBC spec: https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#close--

> It is strongly recommended that an application explicitly commits or rolls back an active transaction prior to calling the close method. If the close method is called and there is an active transaction, the results are implementation-defined.

I discovered the following behaviours:
- DB2JCC requires commit/rollback before active transaction, otherwise `close()` will throw an ERRORCODE=-4471, SQLSTATE=null
- Postgres does not allow commit/rollback when autocommit is on
