### PR TITLE
rollback connection in closeConnectionFully

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -255,6 +255,17 @@ final class PooledConnection extends ConnectionDelegator {
       }
     }
     try {
+      // DB2 (and some other DBMS) may have uncommitted changes and do not allow close
+      // so try to do a rollback.
+      if (!connection.getAutoCommit()) {
+        connection.rollback();
+      }
+    } catch (SQLException ex) {
+      if (logErrors) {
+        Log.warn("Could not perform rollback", ex);
+      }
+    }
+    try {
       connection.close();
       pool.dec();
     } catch (SQLException ex) {


### PR DESCRIPTION
When closeConnectionFully is called (in trim) and the connection may have uncommitted changes, DB2 does not allow to close the connection, so we try to perform a rollback first.

Note: #107 was the originating issue. The fix in https://github.com/ebean-orm/ebean-datasource/pull/108/files#diff-17a97b637b84f5d3e16f487dcd4a8d80d7cdb9f165b528cdc4d495cc93070647R380 should not make this happen by the heartbeat.

Nevertheless, I recommend to perform the rollback here.