### PR TITLE
Heartbeat should not reset, when pool is full

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/ConnectionPoolExhaustedException.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/ConnectionPoolExhaustedException.java
@@ -1,0 +1,13 @@
+package io.ebean.datasource;
+
+import java.sql.SQLException;
+
+/**
+ * This exception is thrown, if the connection pool has reached maxSize.
+ * @author Roland Praml, Foconis Analytics GmbH
+ */
+public class ConnectionPoolExhaustedException extends SQLException {
+  public ConnectionPoolExhaustedException(String reason) {
+    super(reason);
+  }
+}

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -410,6 +410,15 @@ public interface DataSourceBuilder {
   DataSourceBuilder setHeartbeatTimeoutSeconds(int heartbeatTimeoutSeconds);
 
   /**
+   * Sets the coun how often the heartbeat has to detect pool exhaustion in succession.
+   * in succession before an error is raised and the pool will be reset.
+   * <p>
+   * By default, this value must be multiplied with the sum of heartbeatfreq + waitTimeoutMillis to
+   * estimate the time, when the pool will be restarted, because all connections were leaked.
+   */
+  DataSourceBuilder heartbeatMaxPoolExhaustedCount(int count);
+
+  /**
    * Set to true if a stack trace should be captured when obtaining a connection from the pool.
    * <p>
    * This can be used to diagnose a suspected connection pool leak.
@@ -706,6 +715,7 @@ public interface DataSourceBuilder {
    * <p>
    * This is enabled by default. Generally we only want to turn this
    * off when using the pool with a Lambda function.
+   *
    * @param validateOnHeartbeat Use false to disable heartbeat validation.
    */
   DataSourceBuilder validateOnHeartbeat(boolean validateOnHeartbeat);
@@ -899,6 +909,11 @@ public interface DataSourceBuilder {
      * Return the heart beat timeout in seconds.
      */
     int getHeartbeatTimeoutSeconds();
+
+    /**
+     * Return the number, how often the heartbeat has to detect pool exhaustion in succession.
+     */
+    int getHeartbeatMaxPoolExhaustedCount();
 
     /**
      * Return true if a stack trace should be captured when obtaining a connection from the pool.

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -62,6 +62,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private String heartbeatSql;
   private int heartbeatFreqSecs = 30;
   private int heartbeatTimeoutSeconds = 30;
+  private int heartbeatMaxPoolExhaustedCount = 10;
   private boolean captureStackTrace;
   private int maxStackTraceSize = 5;
   private int leakTimeMinutes = 30;
@@ -179,10 +180,10 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     if (minConnections == 2 && other.getMinConnections() < 2) {
       minConnections = other.getMinConnections();
     }
-    if (!shutdownOnJvmExit && other.isShutdownOnJvmExit()){
+    if (!shutdownOnJvmExit && other.isShutdownOnJvmExit()) {
       shutdownOnJvmExit = true;
     }
-    if (validateOnHeartbeat && !other.isValidateOnHeartbeat()){
+    if (validateOnHeartbeat && !other.isValidateOnHeartbeat()) {
       validateOnHeartbeat = false;
     }
     if (customProperties == null) {
@@ -463,6 +464,17 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   @Override
   public DataSourceConfig setHeartbeatTimeoutSeconds(int heartbeatTimeoutSeconds) {
     this.heartbeatTimeoutSeconds = heartbeatTimeoutSeconds;
+    return this;
+  }
+
+  @Override
+  public int getHeartbeatMaxPoolExhaustedCount() {
+    return this.heartbeatMaxPoolExhaustedCount;
+  }
+
+  @Override
+  public DataSourceBuilder heartbeatMaxPoolExhaustedCount(int count) {
+    this.heartbeatMaxPoolExhaustedCount = count;
     return this;
   }
 

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
@@ -1,5 +1,6 @@
 package io.ebean.datasource.pool;
 
+import io.ebean.datasource.ConnectionPoolExhaustedException;
 import io.ebean.datasource.PoolStatus;
 import io.ebean.datasource.pool.ConnectionPool.Status;
 
@@ -271,7 +272,7 @@ final class PooledConnectionQueue {
           dumpBusyConnectionInformation();
         }
 
-        throw new SQLException(msg);
+        throw new ConnectionPoolExhaustedException(msg);
       }
 
       try {

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolFullTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolFullTest.java
@@ -1,0 +1,67 @@
+package io.ebean.datasource.pool;
+
+import io.ebean.datasource.DataSourceAlert;
+import io.ebean.datasource.DataSourceBuilder;
+import io.ebean.datasource.DataSourcePool;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectionPoolFullTest implements DataSourceAlert, WaitFor {
+
+  private static final Logger log = LoggerFactory.getLogger(ConnectionPoolFullTest.class);
+
+  private int up;
+  private int down;
+
+
+  @Test
+  void testPoolFullWithHeartbeat() throws Exception {
+
+    DataSourcePool pool = DataSourceBuilder.create()
+      .url("jdbc:h2:mem:testConnectionPoolFull")
+      .username("sa")
+      .password("sa")
+      .heartbeatFreqSecs(1)
+      .minConnections(1)
+      .maxConnections(1)
+      .trimPoolFreqSecs(1)
+      .alert(this)
+      .failOnStart(false)
+      .build();
+
+    assertThat(up).isEqualTo(1);
+    assertThat(down).isEqualTo(0);
+
+    try {
+      try (Connection connection = pool.getConnection()) {
+        // we do a rollback here
+        System.out.println("So we wait");
+        Thread.sleep(2000);
+        connection.rollback();
+      }
+    } finally {
+      pool.shutdown();
+    }
+    assertThat(up).isEqualTo(1);
+    assertThat(down).isEqualTo(0);
+
+  }
+
+
+  @Override
+  public void dataSourceUp(DataSource dataSource) {
+    up++;
+  }
+
+  @Override
+  public void dataSourceDown(DataSource dataSource, SQLException reason) {
+    down++;
+  }
+}


### PR DESCRIPTION
We discovered an issue, when the connection pool is full, the heartbeat will reset the pool, although this is not necessary.

How to reproduce:

- create a pool (e.g. maxSize = 1)
- start as many threads as `maxSize` that will hold the connection longer than `heartbeatfreq + waitTimeoutMillis`
- heartbeat will not get a connection and thinks, datasource is down, which is not true.

This PR changes, how heartbeat detects, if connection is valid.
- If the pool is full, a `ConnectionPoolExhaustedException extends SQLException` is thrown
- If the hearbeat tries to validate the connection and gets a `ConnectionPoolExhaustedException` it will be ignored multiple times.

We ignore this exception `heartbeatMaxPoolExhaustedCount` times. Normally this is not needed, but if there are really leaking connections (e.g. forgot to close) we perform a reset, if this happened repeatetly

