### PR TITLE
Pstatementcache must be locked in closeConnectionFully

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -245,6 +245,7 @@ final class PooledConnection extends ConnectionDelegator {
         Log.error("Error checking if connection [" + name + "] is closed", ex);
       }
     }
+    lock.lock();
     try {
       for (ExtendedPreparedStatement ps : pstmtCache.values()) {
         ps.closeDestroy();
@@ -253,6 +254,8 @@ final class PooledConnection extends ConnectionDelegator {
       if (logErrors) {
         Log.warn("Error when closing connection Statements", ex);
       }
+    } finally {
+      lock.unlock();
     }
     try {
       connection.close();


### PR DESCRIPTION
We had this exception and can only explain, if the pstatementcache is not properly locked

```
java.util.ConcurrentModificationException: null
        at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:756)
        at java.base/java.util.LinkedHashMap$LinkedValueIterator.next(LinkedHashMap.java:783)
        at io.ebean.datasource.pool.PooledConnection.closeConnectionFully(PooledConnection.java:213)
        at io.ebean.datasource.pool.BusyConnectionBuffer.closeBusyConnection(BusyConnectionBuffer.java:111)
        at io.ebean.datasource.pool.BusyConnectionBuffer.closeBusyConnections(BusyConnectionBuffer.java:101)
        at io.ebean.datasource.pool.PooledConnectionQueue.closeBusyConnections(PooledConnectionQueue.java:402)
        at io.ebean.datasource.pool.PooledConnectionQueue.reset(PooledConnectionQueue.java:328)
        at io.ebean.datasource.pool.ConnectionPool.reset(ConnectionPool.java:563)
        at io.ebean.datasource.pool.ConnectionPool.notifyDataSourceIsDown(ConnectionPool.java:279)
        at io.ebean.datasource.pool.ConnectionPool.testConnection(ConnectionPool.java:366)
        at io.ebean.datasource.pool.ConnectionPool.returnTheConnection(ConnectionPool.java:526)
        at io.ebean.datasource.pool.ConnectionPool.returnConnectionForceClose(ConnectionPool.java:508)
        at io.ebean.datasource.pool.PooledConnection.close(PooledConnection.java:402)
        at io.ebeaninternal.server.transaction.JdbcTransaction.deactivate(JdbcTransaction.java:808)
        at io.ebeaninternal.server.transaction.JdbcTransaction.rollback(JdbcTransaction.java:1055)
        at io.ebeaninternal.api.ScopeTrans.rollback(ScopeTrans.java:194)
        at io.ebeaninternal.api.ScopeTrans.caughtThrowable(ScopeTrans.java:185)
        at io.ebeaninternal.api.ScopeTrans.complete(ScopeTrans.java:120)
        at io.ebeaninternal.api.ScopedTransaction.complete(ScopedTransaction.java:64)
        at io.ebeaninternal.server.transaction.TransactionManager.exitScopedTransaction(TransactionManager.java:469)
        at io.ebeaninternal.server.core.DefaultServer.scopedTransactionExit(DefaultServer.java:718)
        at io.ebeaninternal.api.HelpScopeTrans.exit(HelpScopeTrans.java:26)
```