### PR TITLE
Close connections asynchroniously

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/BusyConnectionBuffer.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/BusyConnectionBuffer.java
@@ -107,7 +107,6 @@ final class BusyConnectionBuffer {
   private void closeBusyConnection(PooledConnection pc) {
     try {
       Log.warn("DataSource closing busy connection? {0}", pc.fullDescription());
-      System.out.println("CLOSING busy connection: " + pc.fullDescription());
       pc.closeConnectionFully(false);
     } catch (Exception ex) {
       Log.error("Error when closing potentially leaked connection " + pc.description(), ex);

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -232,6 +232,13 @@ final class PooledConnection extends ConnectionDelegator {
    * @param logErrors if false then don't log errors when closing
    */
   void closeConnectionFully(boolean logErrors) {
+    pool.closeConnectionFullyAsync(this, logErrors);
+  }
+
+  /**
+   * This method should be executed only by pool.closeConnectionFullyAsync
+   */
+  void doCloseConnectionFully(boolean logErrors) {
     if (Log.isLoggable(System.Logger.Level.TRACE)) {
       Log.trace("Closing Connection[{0}] reason[{1}], pstmtStats: {2}", name, closeReason, pstmtCache.description());
     }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolHangUpTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolHangUpTest.java
@@ -1,0 +1,44 @@
+package io.ebean.datasource.pool;
+
+import io.ebean.datasource.DataSourceBuilder;
+import io.ebean.datasource.DataSourcePool;
+import org.h2.jdbc.JdbcConnection;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+
+public class ConnectionPoolHangUpTest {
+
+  @Test
+  void testHoldLockOnObject() throws Exception {
+    DataSourcePool pool = DataSourceBuilder.create()
+      .url("jdbc:h2:mem:testConnectionPoolHangUp")
+      .username("sa")
+      .password("sa")
+      .heartbeatFreqSecs(1)
+      .minConnections(1)
+      .maxConnections(1)
+      .trimPoolFreqSecs(1)
+      .heartbeatMaxPoolExhaustedCount(0)
+      .failOnStart(false)
+      .build();
+    try {
+      Connection conn = pool.getConnection();
+      Thread t = new Thread(() -> {
+        try {
+          JdbcConnection h2Conn = conn.unwrap(JdbcConnection.class);
+          synchronized (h2Conn) {
+            Thread.sleep(300000);
+          }
+        } catch (Exception e) {
+          // nop
+        }
+      });
+      t.setDaemon(true);
+      t.start();
+    } finally {
+      pool.shutdown();
+    }
+  }
+
+}


### PR DESCRIPTION
We observed on a network outage, that the pool needs a very long time to recover (up to 2 hours) or even dead locks.

We could not reproduce this exactly in a testcase, but we think, that `closeBusyConnections` must wait for locks hold in the connection or statements.

A simple testcase is written for H2, where the thread holds a synchronized lock on the H2 connection. This avoids a proper shutdown of the pool

I would suggest to run closeConnectionFully in an async thread (with a timeout of 5 seconds), because you never know, if connection.close will block and locks up the whole application.