### PR TITLE
closeConnectionFully is performed without lock

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -292,7 +292,7 @@ final class ConnectionPool implements DataSourcePool {
 
   private void notifyDataSourceIsDown(SQLException reason) {
     if (dataSourceUp.get()) {
-      reset();
+      reset(false);
       notifyDown(reason);
     }
   }
@@ -316,7 +316,7 @@ final class ConnectionPool implements DataSourcePool {
 
   private void notifyDataSourceIsUp() {
     if (!dataSourceUp.get()) {
-      reset();
+      reset(true);
       notifyUp();
     }
   }
@@ -553,7 +553,7 @@ final class ConnectionPool implements DataSourcePool {
   }
 
   void removeClosedConnection(PooledConnection pooledConnection) {
-    queue.returnPooledConnection(pooledConnection, true);
+    queue.returnPooledConnection(pooledConnection, true, false);
   }
 
   /**
@@ -564,13 +564,13 @@ final class ConnectionPool implements DataSourcePool {
     if (poolListener != null && !forceClose) {
       poolListener.onBeforeReturnConnection(pooledConnection);
     }
-    queue.returnPooledConnection(pooledConnection, forceClose);
+    queue.returnPooledConnection(pooledConnection, forceClose, true);
   }
 
   void returnConnectionReset(PooledConnection pooledConnection) {
-    queue.returnPooledConnection(pooledConnection, true);
+    queue.returnPooledConnection(pooledConnection, true, false);
     Log.warn("Resetting DataSource on read-only failure [{0}]", name);
-    reset();
+    reset(false);
   }
 
   /**
@@ -599,9 +599,9 @@ final class ConnectionPool implements DataSourcePool {
    * <li>Busy connections are closed when they are returned to the pool.</li>
    * </ul>
    */
-  private void reset() {
+  private void reset(boolean logErrors) {
     heartbeatPoolExhaustedCount = 0;
-    queue.reset(leakTimeMinutes);
+    queue.reset(leakTimeMinutes, logErrors);
   }
 
   /**

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/FreeConnectionBuffer.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/FreeConnectionBuffer.java
@@ -59,18 +59,22 @@ final class FreeConnectionBuffer {
 
   /**
    * Trim any inactive connections that have not been used since usedSince.
+   * <p>
+   * The connections are returned to close.
    */
-  int trim(int minSize, long usedSince, long createdSince) {
-    int trimCount = 0;
+  List<PooledConnection> trim(int minSize, long usedSince, long createdSince) {
+    List<PooledConnection> trimmedConnections = null;
     ListIterator<PooledConnection> iterator = freeBuffer.listIterator(minSize);
     while (iterator.hasNext()) {
       PooledConnection pooledConnection = iterator.next();
       if (pooledConnection.shouldTrim(usedSince, createdSince)) {
         iterator.remove();
-        pooledConnection.closeConnectionFully(true);
-        trimCount++;
+        if (trimmedConnections == null) {
+          trimmedConnections = new ArrayList<>();
+        }
+        trimmedConnections.add(pooledConnection);
       }
     }
-    return trimCount;
+    return trimmedConnections;
   }
 }

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/StaleConnectionException.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/StaleConnectionException.java
@@ -1,0 +1,18 @@
+package io.ebean.datasource.pool;
+
+/**
+ * Used to return a stale connection, so that it can be closed outside a lock.
+ *
+ * @author Roland Praml, Foconis Analytics GmbH
+ */
+class StaleConnectionException extends Exception {
+  private final PooledConnection connection;
+
+  StaleConnectionException(PooledConnection connection) {
+    this.connection = connection;
+  }
+
+  public PooledConnection getConnection() {
+    return connection;
+  }
+}


### PR DESCRIPTION
Note: #127 would be our preferred solution

----

We now might have a better understanding what happened due our network outage.

In #114 we have already identified, that the connection.close may block.

In case of the DB2 driver (and maybe other drivers, too), the connection.close() will communicate with the database.
During `closeConnectionFully` we hold a lock, so that no other thread can obtain new connections (although if there are free ones)

In this PR we tried to do the closeConnectionFully outside of the scope of the lock. This should increase the multi thread performance of the pool.

Please take a look at these changes, if you would agree.

There are still two places, where the closeConnectionFully is called within the lock:
- shutdown -> should not be a problem
- reset -> may be a problem, because the pool will contiune with it's work only if the last connection is closed properly (if the connection pool is huge enough and you may estimate 30sec network timeout, this can take a lot of time)

So I'm unsure how to deal with the reset.
We assume, that restarting the pool took over 2 hours since our last crash.

We also added some more places, where logError is true (to be honest, I will always print the error in closeConnectionFully)