### PR TITLE
StackTraceAsString may stay empty, if cause is in ebean-only classes

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnection.java
@@ -971,6 +971,14 @@ final class PooledConnection extends ConnectionDelegator {
         filteredList.add(stackTraceElement);
       }
     }
+    if (filteredList.isEmpty()) {
+      // the list was empty. Because the error was in ebean code.
+      for (StackTraceElement stackTraceElement : stackTrace) {
+        if (filteredList.size() < maxStackTrace) {
+          filteredList.add(stackTraceElement);
+        }
+      }
+    }
     return filteredList.toString();
   }
 


### PR DESCRIPTION
Due my research, I noticed, that stacktrace may be empty if only filtered classes were involved.
I got `Tried to close a dirty connection at []. See...`
In this case we take all what we can get (up to max stack size) as this is better than the empty list