### PR TITLE
autocommit/rollback may throw error

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -391,10 +391,13 @@ final class ConnectionPool implements DataSourcePool {
     } finally {
       try {
         if (conn != null) {
-          if (!conn.getAutoCommit()) {
-            conn.rollback();
+          try {
+            if (!conn.getAutoCommit()) {
+              conn.rollback();
+            }
+          } finally {
+            conn.closePooledConnection(false);
           }
-          conn.closePooledConnection(false);
         }
       } catch (SQLException ex) {
         Log.warn("Can't close connection in checkDataSource!");


### PR DESCRIPTION
When DB2 connection is in invalid state, getAutocommit may throw an error and connection leak occurs