### PR TITLE
DataSourceConfig.setDefaults() honor a change to maxConnections

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -182,6 +182,9 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     if (minConnections == 2 && other.getMinConnections() < 2) {
       minConnections = other.getMinConnections();
     }
+    if (maxConnections == 200 && other.getMaxConnections() != 200) {
+      maxConnections = other.getMaxConnections();
+    }
     if (!shutdownOnJvmExit && other.isShutdownOnJvmExit()) {
       shutdownOnJvmExit = true;
     }

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -139,6 +139,7 @@ public class DataSourceConfigTest {
     assertThat(readOnly.getUrl()).isEqualTo("jdbc:postgresql://127.0.0.2:5432/unit");
     assertThat(readOnly.getUsername()).isEqualTo("foo2");
     assertThat(readOnly.getMinConnections()).isEqualTo(3);
+    assertThat(readOnly.getMaxConnections()).isEqualTo(20);
     assertThat(readOnly.isShutdownOnJvmExit()).isFalse();
     assertThat(readOnly.isValidateOnHeartbeat()).isFalse();
   }
@@ -163,6 +164,7 @@ public class DataSourceConfigTest {
       .setUsername("foo")
       .setPassword("bar")
       .setMinConnections(1)
+      .setMaxConnections(20)
       .addProperty("useSSL", false);
   }
 


### PR DESCRIPTION
This is typically used when the configuration is used for 2 dataSources - a second readOnly datasource.

Before this change the readOnly datasource would by default get the 200 maxConnections default. With this change it will use the same maxConnections if defined on the main configuration.