### PR TITLE
Copy properties instead of setting as default value

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -140,7 +140,8 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
       copy.customProperties = new LinkedHashMap<>(customProperties);
     }
     if (clientInfo != null) {
-      copy.clientInfo = new Properties(clientInfo);
+      copy.clientInfo = new Properties();
+      copy.clientInfo.putAll(clientInfo);
     }
     copy.initSql = initSql;
     copy.alert = alert;

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/DriverDataSource.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/DriverDataSource.java
@@ -42,7 +42,8 @@ final class DriverDataSource implements DataSource {
 
   @Override
   public Connection getConnection(String username, String password) throws SQLException {
-    final var props = new Properties(connectionProps);
+    final var props = new Properties();
+    props.putAll(connectionProps);
     props.setProperty("user", username);
     props.setProperty("password", password);
     return driver.connect(url, props);
@@ -67,7 +68,8 @@ final class DriverDataSource implements DataSource {
   }
 
   private Connection switchCredentials(Properties properties) throws SQLException {
-    var copy = new Properties(properties);
+    var copy = new Properties();
+    copy.putAll(properties);
     copy.setProperty("password", password2);
     var connection = driver.connect(url, copy);
     // success, permanently switch to use password2 from now on


### PR DESCRIPTION
When you define
```java
final var props = new Properties(connectionProps);
props.setProperty("user", username);
props.setProperty("password", password);
```
and use the Map interface, e.g. `props.keySet()` will return exactly `user` and `password` 

Only a direct access with `property.getValue("someVal")` will fall through to `connectionProps`

Unfortunately some drivers like [H2](https://github.com/h2database/h2database/blob/master/h2/src/main/org/h2/engine/ConnectionInfo.java#L292) and also [MariaDB](https://github.com/mariadb-corporation/mariadb-connector-j/blob/master/src/main/java/org/mariadb/jdbc/Configuration.java#L812) use the Map interface of Properties, which does not expose the underlying default values.

I noticed this, as some custom connection properties were not correctly applied to the driver.

So the use of `Properties(defaults)` can be a trap.
This PR changes all places to copy the defaults to the new object.

@rbygrave this is IMHO a low hanging fruit ;)