### PR TITLE
fixed spelling of captureStackTrace

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/BusyConnectionBuffer.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/BusyConnectionBuffer.java
@@ -119,7 +119,7 @@ final class BusyConnectionBuffer {
    */
   String busyConnectionInformation(boolean toLogger) {
     if (toLogger) {
-      Log.info("Dumping [{0}] busy connections: (Use datasource.xxx.capturestacktrace=true  ... to get stackTraces)", size());
+      Log.info("Dumping [{0}] busy connections: (Use datasource.xxx.captureStackTrace=true  ... to get stackTraces)", size());
     }
     StringBuilder sb = new StringBuilder();
     for (PooledConnection pc : slots) {


### PR DESCRIPTION
when just copy-pasting (and replacing xxx) it did not work... took some time, until I see, that it is all lowercase ;)