### PR TITLE
Fix for DataSourceConfig.setDefaults() when using 2 and 200 for min a…

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -317,7 +317,7 @@ public interface DataSourceBuilder {
   DataSourceBuilder setReadOnly(boolean readOnly);
 
   /**
-   * Set the minimum number of connections the pool should maintain.
+   * Set the minimum number of connections the pool should maintain. Defaults to 2 when not set.
    */
   default DataSourceBuilder minConnections(int minConnections) {
     return setMinConnections(minConnections);
@@ -330,7 +330,7 @@ public interface DataSourceBuilder {
   DataSourceBuilder setMinConnections(int minConnections);
 
   /**
-   * Set the maximum number of connections the pool can reach.
+   * Set the maximum number of connections the pool can reach. Defaults to 200 when not set.
    */
   default DataSourceBuilder maxConnections(int maxConnections) {
     return setMaxConnections(maxConnections);
@@ -892,12 +892,12 @@ public interface DataSourceBuilder {
     boolean isReadOnly();
 
     /**
-     * Return the minimum number of connections the pool should maintain.
+     * Return the minimum number of connections the pool should maintain. Defaults to 2.
      */
     int getMinConnections();
 
     /**
-     * Return the maximum number of connections the pool can reach.
+     * Return the maximum number of connections the pool can reach. Defaults to 200.
      */
     int getMaxConnections();
 

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 @SuppressWarnings("removal")
 public class DataSourceConfig implements DataSourceBuilder.Settings {
 
+  private static final int UNSET = -1;
   private static final String POSTGRES = "postgres";
 
   private String name = "";
@@ -54,8 +55,8 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
    * The optional database owner password (for running InitDatabase).
    */
   private String ownerPassword;
-  private int minConnections = 2;
-  private int maxConnections = 200;
+  private int minConnections = UNSET; // defaults to 2
+  private int maxConnections = UNSET; // defaults to 200
   private int isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
   private boolean autoCommit;
   private boolean readOnly;
@@ -182,10 +183,10 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     if (catalog == null) {
       catalog = other.catalog();
     }
-    if (minConnections == 2 && other.getMinConnections() < 2) {
+    if (minConnections == UNSET) {
       minConnections = other.getMinConnections();
     }
-    if (maxConnections == 200 && other.getMaxConnections() != 200) {
+    if (maxConnections == UNSET) {
       maxConnections = other.getMaxConnections();
     }
     if (!shutdownOnJvmExit && other.isShutdownOnJvmExit()) {
@@ -413,7 +414,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
 
   @Override
   public int getMinConnections() {
-    return minConnections;
+    return minConnections == UNSET ? 2 : minConnections;
   }
 
   @Override
@@ -424,7 +425,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
 
   @Override
   public int getMaxConnections() {
-    return maxConnections;
+    return maxConnections == UNSET ? 200 : maxConnections;
   }
 
   @Override

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -180,6 +180,19 @@ public class DataSourceConfigTest {
   }
 
   @Test
+  void setDefaults_when_explicitSameAsNormalDefaults() {
+    DataSourceConfig readOnly = new DataSourceConfig();
+    readOnly.setMinConnections(2);
+    readOnly.setMaxConnections(200);
+
+    // act
+    readOnly.setDefaults(create());
+
+    assertThat(readOnly.getMinConnections()).isEqualTo(2);
+    assertThat(readOnly.getMaxConnections()).isEqualTo(200);
+  }
+
+  @Test
   public void defaults_someOverride() {
     DataSourceConfig readOnly = new DataSourceConfig();
     readOnly.setUsername("foo2");


### PR DESCRIPTION
…nd max connections

The included test fails without this change. For example, setting maxConnections 200 explicitly can then be "undone" by setDefaults() because 200 is also the magic default for maxConnections.

Using the UNSET -1 value allows it to know when min/max connections have been explicitly set.