### PR TITLE
Add support for initialConnections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ ebean-profiling*.xml
 /db
 /mydb.db
 !src/test/ddl-review/*.sql
-
+.DS_Store
 
 # Intellij project files
 *.iml

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -330,6 +330,17 @@ public interface DataSourceBuilder {
   DataSourceBuilder setMinConnections(int minConnections);
 
   /**
+   * Set the number of initial connections to create when starting.
+   * <p>
+   * When not set the initial number of connections will be min connections.
+   * <p>
+   * The benefit of setting an initial number of connections is for smoother
+   * deployment into an active production system where an application will get
+   * assigned production load.
+   */
+  DataSourceBuilder initialConnections(int initialConnections);
+
+  /**
    * Set the maximum number of connections the pool can reach. Defaults to 200 when not set.
    */
   default DataSourceBuilder maxConnections(int maxConnections) {
@@ -900,6 +911,11 @@ public interface DataSourceBuilder {
      * Return the maximum number of connections the pool can reach. Defaults to 200.
      */
     int getMaxConnections();
+
+    /**
+     * Return the number of initial connections to create on startup.
+     */
+    int getInitialConnections();
 
     /**
      * Return the alert implementation to use.

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
 /**
  * Configuration information for a DataSource.
  *
@@ -56,6 +59,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
    */
   private String ownerPassword;
   private int minConnections = UNSET; // defaults to 2
+  private int initialConnections = UNSET; // defaults to 2
   private int maxConnections = UNSET; // defaults to 200
   private int isolationLevel = Connection.TRANSACTION_READ_COMMITTED;
   private boolean autoCommit;
@@ -116,6 +120,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     copy.driverClassName = driverClassName;
     copy.applicationName = applicationName;
     copy.minConnections = minConnections;
+    copy.initialConnections = initialConnections;
     copy.maxConnections = maxConnections;
     copy.isolationLevel = isolationLevel;
     copy.autoCommit = autoCommit;
@@ -185,6 +190,9 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     }
     if (minConnections == UNSET) {
       minConnections = other.getMinConnections();
+    }
+    if (initialConnections == UNSET) {
+      initialConnections = other.getInitialConnections();
     }
     if (maxConnections == UNSET) {
       maxConnections = other.getMaxConnections();
@@ -420,6 +428,19 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   @Override
   public DataSourceConfig setMinConnections(int minConnections) {
     this.minConnections = minConnections;
+    return this;
+  }
+
+  @Override
+  public int getInitialConnections() {
+    int min = getMinConnections();
+    int max = getMaxConnections();
+    return initialConnections == UNSET ?  min : min(max(min, initialConnections), max);
+  }
+
+  @Override
+  public DataSourceConfig initialConnections(int initialConnections) {
+    this.initialConnections = initialConnections;
     return this;
   }
 
@@ -810,6 +831,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     trimPoolFreqSecs = properties.getInt("trimPoolFreqSecs", trimPoolFreqSecs);
     maxAgeMinutes = properties.getInt("maxAgeMinutes", maxAgeMinutes);
     minConnections = properties.getInt("minConnections", minConnections);
+    initialConnections = properties.getInt("initialConnections", initialConnections);
     maxConnections = properties.getInt("maxConnections", maxConnections);
     pstmtCacheSize = properties.getInt("pstmtCacheSize", pstmtCacheSize);
     cstmtCacheSize = properties.getInt("cstmtCacheSize", cstmtCacheSize);

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -108,6 +108,19 @@ public class DataSourceConfigTest {
   }
 
   @Test
+  void initial_expect_inRangeMinMax() {
+    DataSourceConfig readOnly = new DataSourceConfig();
+    readOnly.setMinConnections(10);
+    readOnly.setMaxConnections(30);
+
+    readOnly.initialConnections(1);
+    assertThat(readOnly.getInitialConnections()).isEqualTo(10);
+
+    readOnly.initialConnections(100);
+    assertThat(readOnly.getInitialConnections()).isEqualTo(30);
+  }
+
+  @Test
   public void copy() {
 
     DataSourceConfig source = new DataSourceConfig();
@@ -134,6 +147,7 @@ public class DataSourceConfigTest {
     assertEquals("sch", copy.getSchema());
     assertEquals("cat", copy.catalog());
     assertEquals(42, copy.getMinConnections());
+    assertEquals(42, copy.getInitialConnections());
     assertEquals(45, copy.getMaxConnections());
 
     customSource.put("a", "modifiedA");
@@ -148,6 +162,7 @@ public class DataSourceConfigTest {
   public void defaults() {
 
     DataSourceConfig config = create();
+    config.initialConnections(6);
 
     var readOnly = new DataSourceConfig().setDefaults(config);
 
@@ -158,6 +173,7 @@ public class DataSourceConfigTest {
     assertThat(readOnly.getSchema()).isEqualTo(config.getSchema());
     assertThat(readOnly.catalog()).isEqualTo(config.catalog());
     assertThat(readOnly.getMinConnections()).isEqualTo(config.getMinConnections());
+    assertThat(readOnly.getInitialConnections()).isEqualTo(config.getInitialConnections());
     assertThat(readOnly.getCustomProperties()).containsKeys("useSSL");
   }
 
@@ -166,6 +182,7 @@ public class DataSourceConfigTest {
     DataSourceConfig readOnly = new DataSourceConfig();
     readOnly.setDefaults(create());
     assertThat(readOnly.getMinConnections()).isEqualTo(1);
+    assertThat(readOnly.getInitialConnections()).isEqualTo(1);
     assertThat(readOnly.getMaxConnections()).isEqualTo(20);
   }
 
@@ -173,10 +190,12 @@ public class DataSourceConfigTest {
   void setDefaults_when_explicit() {
     DataSourceConfig readOnly = new DataSourceConfig();
     readOnly.setMinConnections(21);
-    readOnly.setMaxConnections(22);
+    readOnly.initialConnections(25);
+    readOnly.setMaxConnections(32);
     readOnly.setDefaults(create());
     assertThat(readOnly.getMinConnections()).isEqualTo(21);
-    assertThat(readOnly.getMaxConnections()).isEqualTo(22);
+    assertThat(readOnly.getInitialConnections()).isEqualTo(25);
+    assertThat(readOnly.getMaxConnections()).isEqualTo(32);
   }
 
   @Test
@@ -189,6 +208,7 @@ public class DataSourceConfigTest {
     readOnly.setDefaults(create());
 
     assertThat(readOnly.getMinConnections()).isEqualTo(2);
+    assertThat(readOnly.getInitialConnections()).isEqualTo(2);
     assertThat(readOnly.getMaxConnections()).isEqualTo(200);
   }
 
@@ -210,6 +230,7 @@ public class DataSourceConfigTest {
     assertThat(readOnly.getUrl()).isEqualTo("jdbc:postgresql://127.0.0.2:5432/unit");
     assertThat(readOnly.getUsername()).isEqualTo("foo2");
     assertThat(readOnly.getMinConnections()).isEqualTo(3);
+    assertThat(readOnly.getInitialConnections()).isEqualTo(3);
     assertThat(readOnly.getMaxConnections()).isEqualTo(20);
     assertThat(readOnly.isShutdownOnJvmExit()).isFalse();
     assertThat(readOnly.isValidateOnHeartbeat()).isFalse();
@@ -269,6 +290,7 @@ public class DataSourceConfigTest {
 
     var builder = DataSourceBuilder.from(props, "bar");
     assertConfigValues(builder.settings());
+    assertThat(builder.settings().getInitialConnections()).isEqualTo(12);
   }
 
   @Test
@@ -288,16 +310,19 @@ public class DataSourceConfigTest {
 
     assertThat(builder.settings().getMaxConnections()).isEqualTo(100);
     assertThat(builder.settings().getMinConnections()).isEqualTo(3);
+    assertThat(builder.settings().getInitialConnections()).isEqualTo(3);
   }
 
   @Test
   public void alsoIf_notApplied() {
     var builder = DataSourceBuilder.create()
       .alsoIf(() -> false, this::myConfig)
-      .minConnections(3);
+      .minConnections(3)
+      .initialConnections(6);
 
     assertThat(builder.settings().getMaxConnections()).isEqualTo(200);
     assertThat(builder.settings().getMinConnections()).isEqualTo(3);
+    assertThat(builder.settings().getInitialConnections()).isEqualTo(6);
   }
 
   private void myConfig(DataSourceBuilder.Settings builder) {

--- a/ebean-datasource-api/src/test/resources/example2.properties
+++ b/ebean-datasource-api/src/test/resources/example2.properties
@@ -6,3 +6,4 @@ bar.url=myUrl
 bar.readOnlyUrl=myReadOnlyUrl
 bar.applicationName=myApp
 bar.clientInfo=ClientUser=ciu;ClientHostname=cih
+bar.initialConnections=12

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -82,6 +82,7 @@ final class ConnectionPool implements DataSourcePool {
   private final AtomicBoolean dataSourceUp = new AtomicBoolean(false);
   private SQLException dataSourceDownReason;
   private final int minConnections;
+  private final int initialConnections;
   private int maxConnections;
   private final int waitTimeoutMillis;
   private final int pstmtCacheSize;
@@ -121,6 +122,7 @@ final class ConnectionPool implements DataSourcePool {
     this.maxStackTraceSize = params.getMaxStackTraceSize();
     this.pstmtCacheSize = params.getPstmtCacheSize();
     this.minConnections = params.getMinConnections();
+    this.initialConnections = params.getInitialConnections();
     this.maxConnections = params.getMaxConnections();
     this.waitTimeoutMillis = params.getWaitTimeoutMillis();
     this.heartbeatFreqSecs = params.getHeartbeatFreqSecs();
@@ -175,7 +177,7 @@ final class ConnectionPool implements DataSourcePool {
   private void tryEnsureMinimumConnections() {
     notifyLock.lock();
     try {
-      queue.ensureMinimumConnections();
+      queue.createConnections(initialConnections);
       // if we successfully come up without an exception, send datasource up
       // notification. This makes it easier, because the application needs not
       // to implement special handling, if the db comes up the first time or not.
@@ -193,7 +195,7 @@ final class ConnectionPool implements DataSourcePool {
     long start = System.currentTimeMillis();
     dataSourceUp.set(true);
     if (failOnStart) {
-      queue.ensureMinimumConnections();
+      queue.createConnections(initialConnections);
     } else {
       tryEnsureMinimumConnections();
     }

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTrimIdleTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTrimIdleTest.java
@@ -20,6 +20,7 @@ public class ConnectionPoolTrimIdleTest implements WaitFor {
     config.setUsername("sa");
     config.setPassword("");
     config.setMinConnections(1);
+    config.initialConnections(3);
     config.setMaxConnections(10);
     config.setMaxInactiveTimeSecs(1);
     config.setTrimPoolFreqSecs(1);
@@ -32,7 +33,7 @@ public class ConnectionPoolTrimIdleTest implements WaitFor {
   public void test() throws SQLException, InterruptedException {
 
     ConnectionPool pool = createPool();
-    assertThat(pool.size()).isEqualTo(1);
+    assertThat(pool.size()).isEqualTo(3);
     try {
       Connection con1 = pool.getConnection();
       Connection con2 = pool.getConnection();


### PR DESCRIPTION
Allows a pool to be started with initialConnections that can be more than minConnections. This is useful when an application is deployed into something like K8s where a pod will quickly get full production load assigned to it (and we prefer more initial connections for that initial period).