### PR TITLE
Adjust the prepared statement cache default from 100 to 300

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceBuilder.java
@@ -485,14 +485,23 @@ public interface DataSourceBuilder {
   /**
    * Set the size of the PreparedStatement cache (per connection).
    * <p>
-   * Defaults to 100.
+   * Defaults to 300.
    */
   default DataSourceBuilder pstmtCacheSize(int pstmtCacheSize) {
     return setPstmtCacheSize(pstmtCacheSize);
   }
 
   /**
-   * @deprecated - migrate to {@link #pstmtCacheSize(int)}.
+   * Set the size of the PreparedStatement cache (per connection).
+   * <p>
+   * Defaults to 300.
+   */
+  default DataSourceBuilder preparedStatementCacheSize(int pstmtCacheSize) {
+    return setPstmtCacheSize(pstmtCacheSize);
+  }
+
+  /**
+   * @deprecated - migrate to {@link #preparedStatementCacheSize(int)}.
    */
   @Deprecated
   DataSourceBuilder setPstmtCacheSize(int pstmtCacheSize);

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -74,7 +74,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private int maxInactiveTimeSecs = 300;
   private int maxAgeMinutes = 0;
   private int trimPoolFreqSecs = 59;
-  private int pstmtCacheSize = 100;
+  private int pstmtCacheSize = 300;
   private int cstmtCacheSize = 20;
   private int waitTimeoutMillis = 1000;
   private String poolListener;

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -353,6 +353,39 @@ public class DataSourceConfigTest {
     assertConfigValues(builder2.settings());
   }
 
+  @Test
+  void pstmtCacheSize_default_expect_300() {
+    DataSourceConfig config = new DataSourceConfig();
+    assertThat(config.getPstmtCacheSize()).isEqualTo(300);
+  }
+
+  @Test
+  void pstmtCacheSize_explicit_setValue() {
+    DataSourceConfig config = new DataSourceConfig();
+    config.setPstmtCacheSize(500);
+    assertThat(config.getPstmtCacheSize()).isEqualTo(500);
+  }
+
+  @Test
+  void pstmtCacheSize_builder_method() {
+    var builder = DataSourceBuilder.create()
+      .pstmtCacheSize(250);
+    assertThat(builder.settings().getPstmtCacheSize()).isEqualTo(250);
+  }
+
+  @Test
+  void preparedStatementCacheSize_builder_method() {
+    var builder = DataSourceBuilder.create()
+      .preparedStatementCacheSize(400);
+    assertThat(builder.settings().getPstmtCacheSize()).isEqualTo(400);
+  }
+
+  @Test
+  void preparedStatementCacheSize_builder_default() {
+    var builder = DataSourceBuilder.create();
+    assertThat(builder.settings().getPstmtCacheSize()).isEqualTo(300);
+  }
+
   private static void assertConfigValues(DataSourceBuilder.Settings config) {
     assertThat(config.getReadOnlyUrl()).isEqualTo("myReadOnlyUrl");
     assertThat(config.getUrl()).isEqualTo("myUrl");


### PR DESCRIPTION
Additionally add a more friendly preparedStatementCacheSize() method to DataSourceBuilder