### PR TITLE
Mark DataSourceFactory.create() as deprecated in favour of DataSource…

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceFactory.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceFactory.java
@@ -5,12 +5,12 @@ package io.ebean.datasource;
  *
  * <pre>{@code
  *
- *     DataSourceConfig config = new DataSourceConfig();
- *     config.setUrl("jdbc:h2:mem:tests2");
- *     config.setUsername("sa");
- *     config.setPassword("");
- *
- *     DataSourcePool pool = DataSourceFactory.create("test", config);
+ *     DataSourcePool pool = DataSourcePool.builder()
+ *       .name("test")
+ *       .url("jdbc:h2:mem:tests2")
+ *       .username("sa")
+ *       .password("")
+ *       .build();
  *
  *     Connection connection = pool.getConnection();
  *
@@ -20,7 +20,20 @@ public interface DataSourceFactory {
 
   /**
    * Create the DataSourcePool given the name and configuration.
+   *
+   * @deprecated Migrate to {@link DataSourcePool#builder()} and {@link DataSourceBuilder#build()}.
+   * <pre>{@code
+   *
+   *     DataSourcePool pool = DataSourcePool.builder()
+   *       .name("test")
+   *       .url("jdbc:h2:mem:tests2")
+   *       .username("sa")
+   *       .password("")
+   *       .build();
+   *
+   * }</pre>
    */
+  @Deprecated
   static DataSourcePool create(String name, DataSourceConfig config) {
     config.defaultConnectionInitializer(DSManager.defaultInitializer());
     return DSManager.get().createPool(name, config);

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/DataSourcePoolFactoryTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/DataSourcePoolFactoryTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DataSourcePoolFactoryTest {
 
   @Test
+  @SuppressWarnings("deprecation") // intentionally covers the deprecated DataSourceFactory.create()
   void createPool() throws Exception {
 
     DataSourceConfig config = new DataSourceConfig();

--- a/ebean-datasource/src/test/java/io/ebean/datasource/test/PostgresInitTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/test/PostgresInitTest.java
@@ -2,7 +2,6 @@ package io.ebean.datasource.test;
 
 import io.ebean.datasource.DataSourceBuilder;
 import io.ebean.datasource.DataSourceConfig;
-import io.ebean.datasource.DataSourceFactory;
 import io.ebean.datasource.DataSourcePool;
 import io.ebean.test.containers.PostgresContainer;
 import org.junit.jupiter.api.AfterAll;
@@ -86,7 +85,7 @@ class PostgresInitTest {
     ds.setPassword("test");
     ds.setApplicationName("my-application-name");
 
-    DataSourcePool pool = DataSourceFactory.create("app", ds);
+    DataSourcePool pool = ds.name("app").build();
     try {
       try (Connection connection = pool.getConnection()) {
         setupTable(connection, "my_table");
@@ -117,7 +116,7 @@ class PostgresInitTest {
     ds.setPassword("test");
     ds.setPassword2("newRolledPassword");
 
-    DataSourcePool pool = DataSourceFactory.create("app", ds);
+    DataSourcePool pool = ds.name("app").build();
     try {
       try (Connection connection0 = pool.getConnection()) {
         setupTable(connection0, "my_table2");
@@ -147,7 +146,7 @@ class PostgresInitTest {
         }
 
         // a new pool switches immediately
-        DataSourcePool pool2 = DataSourceFactory.create("app2", ds);
+        DataSourcePool pool2 = ds.name("app2").build();
         try (var connP2_0 = pool2.getConnection()) {
           testConnectionWithSelect(connP2_0, "select acol from app.my_table2");
           try (var connP2_1 = pool2.getConnection()) {


### PR DESCRIPTION
…Pool.builder()