### PR TITLE
Bug fix for propagation of pstmtCacheSize and cstmtCacheSize from mai…

### DIFF
--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -74,8 +74,8 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private int maxInactiveTimeSecs = 300;
   private int maxAgeMinutes = 0;
   private int trimPoolFreqSecs = 59;
-  private int pstmtCacheSize = 300;
-  private int cstmtCacheSize = 20;
+  private int pstmtCacheSize = UNSET; // defaults to 300
+  private int cstmtCacheSize = UNSET; // defaults to 20
   private int waitTimeoutMillis = 1000;
   private String poolListener;
   private boolean offline;
@@ -197,6 +197,12 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
     }
     if (maxConnections == UNSET) {
       maxConnections = other.getMaxConnections();
+    }
+    if (pstmtCacheSize == UNSET) {
+      pstmtCacheSize = other.getPstmtCacheSize();
+    }
+    if (cstmtCacheSize == UNSET) {
+      cstmtCacheSize = other.getCstmtCacheSize();
     }
     if (!shutdownOnJvmExit && other.isShutdownOnJvmExit()) {
       shutdownOnJvmExit = true;
@@ -576,7 +582,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
 
   @Override
   public int getPstmtCacheSize() {
-    return pstmtCacheSize;
+    return pstmtCacheSize == UNSET ? 300 : pstmtCacheSize;
   }
 
   @Override
@@ -587,7 +593,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
 
   @Override
   public int getCstmtCacheSize() {
-    return cstmtCacheSize;
+    return cstmtCacheSize == UNSET ? 20 : cstmtCacheSize;
   }
 
   @Override

--- a/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
+++ b/ebean-datasource-api/src/test/java/io/ebean/datasource/DataSourceConfigTest.java
@@ -199,6 +199,43 @@ public class DataSourceConfigTest {
   }
 
   @Test
+  void setDefaults_inheritsStatementCacheSizes_whenNotExplicit() {
+    DataSourceConfig main = create();
+    main.setPstmtCacheSize(50);
+    main.setCstmtCacheSize(11);
+
+    DataSourceConfig readOnly = new DataSourceConfig();
+    readOnly.setDefaults(main);
+
+    assertThat(readOnly.getPstmtCacheSize()).isEqualTo(50);
+    assertThat(readOnly.getCstmtCacheSize()).isEqualTo(11);
+  }
+
+  @Test
+  void setDefaults_keepsExplicitStatementCacheSizes() {
+    DataSourceConfig main = create();
+    main.setPstmtCacheSize(50);
+    main.setCstmtCacheSize(11);
+
+    DataSourceConfig readOnly = new DataSourceConfig();
+    readOnly.setPstmtCacheSize(70);
+    readOnly.setCstmtCacheSize(9);
+    readOnly.setDefaults(main);
+
+    assertThat(readOnly.getPstmtCacheSize()).isEqualTo(70);
+    assertThat(readOnly.getCstmtCacheSize()).isEqualTo(9);
+  }
+
+  @Test
+  void setDefaults_inheritsStatementCacheSizes_whenMainAlsoDefault() {
+    DataSourceConfig readOnly = new DataSourceConfig();
+    readOnly.setDefaults(create());
+
+    assertThat(readOnly.getPstmtCacheSize()).isEqualTo(300);
+    assertThat(readOnly.getCstmtCacheSize()).isEqualTo(20);
+  }
+
+  @Test
   void setDefaults_when_explicitSameAsNormalDefaults() {
     DataSourceConfig readOnly = new DataSourceConfig();
     readOnly.setMinConnections(2);


### PR DESCRIPTION
…n to readOnly Datasource

Currently this propagation doesn't happen and when we reduce the pstmtCacheSize size on a main datasource this isn't propagated to the readonly one.

This was picked up with a CI build failure with oracle, when the default pstmtCacheSize bumped to 300, this has meant it hits a too-many-cursors error with the CI Oracle build for ebean.