### PR TITLE
Add method PoolStatus collect(boolean delta) to support concurrent DELTA and CUMULATIVE metrics collection

### DIFF
--- a/docs/guides/monitoring-pool-metrics.md
+++ b/docs/guides/monitoring-pool-metrics.md
@@ -20,6 +20,19 @@ System.out.printf(
   status.waiting(), status.highWaterMark(), status.hitCount(), status.waitCount());
 ```
 
+For a collector that needs either cumulative or delta additive metrics, use
+`collect(boolean delta)`:
+
+```java
+PoolStatus cumulative = pool.collect(false);
+PoolStatus delta = pool.collect(true); // since the previous delta collection
+```
+
+Only one DELTA collector is supported. `highWaterMark()` and
+`maxAcquireMicros()` are collection-window maximums and reset after every
+`collect()` call, regardless of the `delta` value. The existing
+`status(boolean reset)` method retains its reset semantics.
+
 ### Metric meanings
 
 | Metric | Meaning |
@@ -30,7 +43,7 @@ System.out.printf(
 | `busy()` | Connections **currently** checked out, at the instant `status()` is called (point-in-time snapshot — see note below). |
 | `size()` | `free() + busy()` — total connections in the pool right now. |
 | `waiting()` | Threads currently blocked waiting for a connection (point-in-time snapshot). |
-| `highWaterMark()` | **Peak** `busy()` value seen since the last reset — the metric to use for "how busy was the pool". |
+| `highWaterMark()` | **Peak** `busy()` value seen since the last reset or collection — the metric to use for "how busy was the pool". |
 | `hitCount()` | Number of times a connection was requested from the pool. |
 | `waitCount()` | Number of times a thread had to wait (pool was full). |
 | `totalAcquireMicros()` | Total time spent acquiring connections (micros). |

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourcePool.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourcePool.java
@@ -101,6 +101,18 @@ public interface DataSourcePool extends DataSource {
   PoolStatus status(boolean reset);
 
   /**
+   * Collect pool metrics.
+   * <p>
+   * When {@code delta} is false, additive metrics are returned cumulatively. When
+   * {@code delta} is true, additive metrics are returned since the previous delta
+   * collection. Only one delta collector is supported.
+   * <p>
+   * Max metrics are returned for the current collection window and reset after
+   * collection, regardless of the value of {@code delta}.
+   */
+  PoolStatus collect(boolean delta);
+
+  /**
    * Returns the reason, why the dataSource is down.
    */
   SQLException dataSourceDownReason();

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -887,6 +887,11 @@ final class ConnectionPool implements DataSourcePool {
     return queue.status(reset);
   }
 
+  @Override
+  public PoolStatus collect(boolean delta) {
+    return queue.collect(delta);
+  }
+
   static final class Status implements PoolStatus {
 
     private final int minSize;

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
@@ -51,9 +51,13 @@ final class PooledConnectionQueue {
    * Number of times a connection was got from this queue.
    */
   private int hitCount;
+  private int lastWaitCount;
+  private int lastHitCount;
   private long totalAcquireNanos;
   private long maxAcquireNanos;
   private long totalWaitNanos;
+  private long lastTotalAcquireNanos;
+  private long lastTotalWaitNanos;
 
   /**
    * The high water mark for the queue size.
@@ -101,17 +105,52 @@ final class PooledConnectionQueue {
     try {
       PoolStatus s = createStatus();
       if (reset) {
-        highWaterMark = busyList.size();
-        hitCount = 0;
-        waitCount = 0;
-        maxAcquireNanos = 0;
-        totalAcquireNanos = 0;
-        totalWaitNanos = 0;
+        resetMetrics();
       }
       return s;
     } finally {
       lock.unlock();
     }
+  }
+
+  PoolStatus collect(boolean delta) {
+    lock.lock();
+    try {
+      var collectedWaitCount = delta ? waitCount - lastWaitCount : waitCount;
+      var collectedHitCount = delta ? hitCount - lastHitCount : hitCount;
+      var collectedTotalAcquireNanos = delta ? totalAcquireNanos - lastTotalAcquireNanos : totalAcquireNanos;
+      var collectedTotalWaitNanos = delta ? totalWaitNanos - lastTotalWaitNanos : totalWaitNanos;
+      var status = new Status(minSize, maxSize, freeList.size(), busyList.size(), waitingThreads, highWaterMark,
+        collectedWaitCount, collectedHitCount, collectedTotalAcquireNanos, maxAcquireNanos, collectedTotalWaitNanos);
+      if (delta) {
+        lastWaitCount = waitCount;
+        lastHitCount = hitCount;
+        lastTotalAcquireNanos = totalAcquireNanos;
+        lastTotalWaitNanos = totalWaitNanos;
+      }
+      resetMaxMetrics();
+      return status;
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void resetMetrics() {
+    highWaterMark = busyList.size();
+    hitCount = 0;
+    waitCount = 0;
+    maxAcquireNanos = 0;
+    totalAcquireNanos = 0;
+    totalWaitNanos = 0;
+    lastHitCount = 0;
+    lastWaitCount = 0;
+    lastTotalAcquireNanos = 0;
+    lastTotalWaitNanos = 0;
+  }
+
+  private void resetMaxMetrics() {
+    highWaterMark = busyList.size();
+    maxAcquireNanos = 0;
   }
 
   void setMaxSize(int maxSize) {
@@ -456,4 +495,3 @@ final class PooledConnectionQueue {
   }
 
 }
-

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolFullTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolFullTest.java
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConnectionPoolFullTest implements DataSourceAlert {
+class ConnectionPoolFullTest implements DataSourceAlert {
 
   private int up;
   private int down;
@@ -56,8 +56,8 @@ public class ConnectionPoolFullTest implements DataSourceAlert {
       assertThat(up).isEqualTo(1);
       assertThat(down).isEqualTo(1);
 
-      System.out.println("waiting 2s for recovery");
-      Thread.sleep(2000);
+      System.out.println("waiting 4s for recovery");
+      Thread.sleep(4000);
       assertThat(up).isEqualTo(2);
       assertThat(down).isEqualTo(1);
 

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTest.java
@@ -115,6 +115,45 @@ class ConnectionPoolTest {
   }
 
   @Test
+  void collect_supportsCumulativeAndDeltaMetrics() throws SQLException {
+    var first = pool.getConnection();
+    var second = pool.getConnection();
+
+    PoolStatus cumulative = pool.collect(false);
+    assertThat(cumulative.hitCount()).isEqualTo(2);
+    assertThat(cumulative.highWaterMark()).isEqualTo(2);
+
+    first.rollback();
+    first.close();
+    second.rollback();
+    second.close();
+
+    PoolStatus cumulativeAgain = pool.collect(false);
+    assertThat(cumulativeAgain.hitCount()).isEqualTo(2);
+    assertThat(cumulativeAgain.highWaterMark()).isEqualTo(2);
+
+    PoolStatus delta = pool.collect(true);
+    assertThat(delta.hitCount()).isEqualTo(2);
+    assertThat(delta.highWaterMark()).isEqualTo(0);
+
+    PoolStatus emptyDelta = pool.collect(true);
+    assertThat(emptyDelta.hitCount()).isEqualTo(0);
+  }
+
+  @Test
+  void status_resetResetsCollectDeltaBaseline() throws SQLException {
+    var connection = pool.getConnection();
+    connection.rollback();
+    connection.close();
+
+    pool.status(true);
+
+    PoolStatus delta = pool.collect(true);
+    assertThat(delta.hitCount()).isEqualTo(0);
+    assertThat(delta.totalAcquireMicros()).isEqualTo(0);
+  }
+
+  @Test
   void getConnection_explicitUserPassword() throws SQLException {
     Connection connection = pool.getConnection("sa", "");
     PreparedStatement statement = connection.prepareStatement("create user testing password '123'");


### PR DESCRIPTION
Prior to this it was support to collect EITHER delta or cumulative but not both concurrently. With this change there we can have a single DELTA collector and any number of CUMULATIVE collectors running at the same time.