### PR TITLE
Metrics collection for maxAcquireNanos and highWaterMark resets on 1 …

### DIFF
--- a/docs/guides/monitoring-pool-metrics.md
+++ b/docs/guides/monitoring-pool-metrics.md
@@ -28,9 +28,9 @@ PoolStatus cumulative = pool.collect(false);
 PoolStatus delta = pool.collect(true); // since the previous delta collection
 ```
 
-Only one DELTA collector is supported. `highWaterMark()` and
-`maxAcquireMicros()` are collection-window maximums and reset after every
-`collect()` call, regardless of the `delta` value. The existing
+Only one DELTA collector is supported. Max metrics are shared by all collectors:
+the first `collect()` call after 59 seconds publishes and resets the max-metrics
+window, and all collectors then observe the same published maximum. The existing
 `status(boolean reset)` method retains its reset semantics.
 
 ### Metric meanings
@@ -43,7 +43,7 @@ Only one DELTA collector is supported. `highWaterMark()` and
 | `busy()` | Connections **currently** checked out, at the instant `status()` is called (point-in-time snapshot — see note below). |
 | `size()` | `free() + busy()` — total connections in the pool right now. |
 | `waiting()` | Threads currently blocked waiting for a connection (point-in-time snapshot). |
-| `highWaterMark()` | **Peak** `busy()` value seen since the last reset or collection — the metric to use for "how busy was the pool". |
+| `highWaterMark()` | **Peak** `busy()` value seen in the published 59-second collection window — the metric to use for "how busy was the pool". |
 | `hitCount()` | Number of times a connection was requested from the pool. |
 | `waitCount()` | Number of times a thread had to wait (pool was full). |
 | `totalAcquireMicros()` | Total time spent acquiring connections (micros). |

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/ConnectionPool.java
@@ -13,6 +13,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
 
 /**
  * A robust DataSource implementation.
@@ -107,6 +108,10 @@ final class ConnectionPool implements DataSourcePool {
   private Thread shutdownHook;
 
   ConnectionPool(String name, DataSourceConfig params) {
+    this(name, params, System::nanoTime);
+  }
+
+  ConnectionPool(String name, DataSourceConfig params, LongSupplier nanoTime) {
     this.config = params;
     this.name = name;
     this.notify = params.getAlert();
@@ -137,7 +142,7 @@ final class ConnectionPool implements DataSourcePool {
     this.validateStaleMillis = params.validateStaleMillis();
     this.applicationName = params.getApplicationName();
     this.clientInfo = params.getClientInfo();
-    this.queue = new PooledConnectionQueue(this);
+    this.queue = new PooledConnectionQueue(this, nanoTime);
     this.schema = params.getSchema();
     this.catalog = params.catalog();
     this.user = params.getUsername();

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
@@ -5,6 +5,7 @@ import io.ebean.datasource.PoolStatus;
 import io.ebean.datasource.pool.ConnectionPool.Status;
 
 import java.sql.SQLException;
+import java.util.function.LongSupplier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -14,6 +15,7 @@ import static java.lang.System.Logger.Level.DEBUG;
 final class PooledConnectionQueue {
 
   private static final TimeUnit MILLIS_TIME_UNIT = TimeUnit.MILLISECONDS;
+  private static final long MAX_METRICS_WINDOW_NANOS = TimeUnit.SECONDS.toNanos(59);
 
   private final String name;
   private final ConnectionPool pool;
@@ -58,6 +60,10 @@ final class PooledConnectionQueue {
   private long totalWaitNanos;
   private long lastTotalAcquireNanos;
   private long lastTotalWaitNanos;
+  private final LongSupplier nanoTime;
+  private long lastMaxResetNanos;
+  private int publishedHighWaterMark;
+  private long publishedMaxAcquireNanos;
 
   /**
    * The high water mark for the queue size.
@@ -71,7 +77,7 @@ final class PooledConnectionQueue {
   private boolean doingShutdown;
   private final long validateStaleMillis;
 
-  PooledConnectionQueue(ConnectionPool pool) {
+  PooledConnectionQueue(ConnectionPool pool, LongSupplier nanoTime) {
     this.pool = pool;
     this.name = pool.name();
     this.minSize = pool.minSize();
@@ -83,6 +89,8 @@ final class PooledConnectionQueue {
     this.freeList = new FreeConnectionBuffer();
     this.lock = new ReentrantLock(false);
     this.notEmpty = lock.newCondition();
+    this.nanoTime = nanoTime;
+    this.lastMaxResetNanos = nanoTime.getAsLong() - MAX_METRICS_WINDOW_NANOS;
   }
 
   private PoolStatus createStatus() {
@@ -105,7 +113,7 @@ final class PooledConnectionQueue {
     try {
       PoolStatus s = createStatus();
       if (reset) {
-        resetMetrics();
+        resetMetrics(nanoTime.getAsLong());
       }
       return s;
     } finally {
@@ -116,26 +124,31 @@ final class PooledConnectionQueue {
   PoolStatus collect(boolean delta) {
     lock.lock();
     try {
+      var now = nanoTime.getAsLong();
+      if (now - lastMaxResetNanos >= MAX_METRICS_WINDOW_NANOS) {
+        publishedHighWaterMark = highWaterMark;
+        publishedMaxAcquireNanos = maxAcquireNanos;
+        resetMaxMetrics(now);
+      }
       var collectedWaitCount = delta ? waitCount - lastWaitCount : waitCount;
       var collectedHitCount = delta ? hitCount - lastHitCount : hitCount;
       var collectedTotalAcquireNanos = delta ? totalAcquireNanos - lastTotalAcquireNanos : totalAcquireNanos;
       var collectedTotalWaitNanos = delta ? totalWaitNanos - lastTotalWaitNanos : totalWaitNanos;
-      var status = new Status(minSize, maxSize, freeList.size(), busyList.size(), waitingThreads, highWaterMark,
-        collectedWaitCount, collectedHitCount, collectedTotalAcquireNanos, maxAcquireNanos, collectedTotalWaitNanos);
+      var status = new Status(minSize, maxSize, freeList.size(), busyList.size(), waitingThreads, publishedHighWaterMark,
+        collectedWaitCount, collectedHitCount, collectedTotalAcquireNanos, publishedMaxAcquireNanos, collectedTotalWaitNanos);
       if (delta) {
         lastWaitCount = waitCount;
         lastHitCount = hitCount;
         lastTotalAcquireNanos = totalAcquireNanos;
         lastTotalWaitNanos = totalWaitNanos;
       }
-      resetMaxMetrics();
       return status;
     } finally {
       lock.unlock();
     }
   }
 
-  private void resetMetrics() {
+  private void resetMetrics(long now) {
     highWaterMark = busyList.size();
     hitCount = 0;
     waitCount = 0;
@@ -146,11 +159,15 @@ final class PooledConnectionQueue {
     lastWaitCount = 0;
     lastTotalAcquireNanos = 0;
     lastTotalWaitNanos = 0;
+    publishedHighWaterMark = highWaterMark;
+    publishedMaxAcquireNanos = maxAcquireNanos;
+    lastMaxResetNanos = now;
   }
 
-  private void resetMaxMetrics() {
+  private void resetMaxMetrics(long now) {
     highWaterMark = busyList.size();
     maxAcquireNanos = 0;
+    lastMaxResetNanos = now;
   }
 
   void setMaxSize(int maxSize) {

--- a/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTest.java
+++ b/ebean-datasource/src/test/java/io/ebean/datasource/pool/ConnectionPoolTest.java
@@ -9,11 +9,14 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class ConnectionPoolTest {
 
+  private final AtomicLong nanoTime = new AtomicLong();
   private final ConnectionPool pool;
 
   ConnectionPoolTest() {
@@ -28,7 +31,7 @@ class ConnectionPoolTest {
     config.setMinConnections(2);
     config.setMaxConnections(4);
 
-    return new ConnectionPool("test", config);
+    return new ConnectionPool("test", config, nanoTime::get);
   }
 
   @AfterEach
@@ -119,6 +122,7 @@ class ConnectionPoolTest {
     var first = pool.getConnection();
     var second = pool.getConnection();
 
+    nanoTime.addAndGet(TimeUnit.SECONDS.toNanos(59));
     PoolStatus cumulative = pool.collect(false);
     assertThat(cumulative.hitCount()).isEqualTo(2);
     assertThat(cumulative.highWaterMark()).isEqualTo(2);
@@ -134,10 +138,33 @@ class ConnectionPoolTest {
 
     PoolStatus delta = pool.collect(true);
     assertThat(delta.hitCount()).isEqualTo(2);
-    assertThat(delta.highWaterMark()).isEqualTo(0);
+    assertThat(delta.highWaterMark()).isEqualTo(2);
 
     PoolStatus emptyDelta = pool.collect(true);
     assertThat(emptyDelta.hitCount()).isEqualTo(0);
+    assertThat(emptyDelta.highWaterMark()).isEqualTo(2);
+  }
+
+  @Test
+  void collect_publishesSharedMaxSnapshotAfterWindow() throws SQLException {
+    var first = pool.getConnection();
+    var second = pool.getConnection();
+    first.close();
+    second.close();
+
+    nanoTime.addAndGet(TimeUnit.SECONDS.toNanos(59));
+    assertThat(pool.collect(false).highWaterMark()).isEqualTo(2);
+
+    var connection = pool.getConnection();
+    assertThat(pool.collect(false).highWaterMark()).isEqualTo(2);
+    connection.close();
+
+    nanoTime.addAndGet(TimeUnit.SECONDS.toNanos(59));
+
+    PoolStatus cumulative = pool.collect(false);
+    PoolStatus delta = pool.collect(true);
+    assertThat(cumulative.highWaterMark()).isEqualTo(1);
+    assertThat(delta.highWaterMark()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
…minute window

This now supports multiple metrics collectors (1 delta, any number of cumulative collectors).

The effective change here is that the "max" metrics reset based on an internal 1 minute window.