### PR TITLE
Progressively trim excess idle connections

### DIFF
--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/FreeConnectionBuffer.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/FreeConnectionBuffer.java
@@ -60,10 +60,10 @@ final class FreeConnectionBuffer {
   /**
    * Trim any inactive connections that have not been used since usedSince.
    */
-  List<PooledConnection> trim(int minSize, long usedSince, long createdSince) {
+  List<PooledConnection> trim(int minSize, long usedSince, long createdSince, int maxTrim) {
     var trimmed = new ArrayList<PooledConnection>();
     ListIterator<PooledConnection> iterator = freeBuffer.listIterator(minSize);
-    while (iterator.hasNext()) {
+    while (iterator.hasNext() && trimmed.size() < maxTrim) {
       PooledConnection pooledConnection = iterator.next();
       if (pooledConnection.shouldTrim(usedSince, createdSince)) {
         iterator.remove();

--- a/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
+++ b/ebean-datasource/src/main/java/io/ebean/datasource/pool/PooledConnectionQueue.java
@@ -526,10 +526,13 @@ final class PooledConnectionQueue {
     if (freeList.size() > minSize) {
       // trim on maxInactive and maxAge
       long usedSince = System.currentTimeMillis() - maxInactiveMillis;
-      trimmedConnections = freeList.trim(minSize, usedSince, createdSince);
+      int excess = freeList.size() - minSize;
+      // Progressively reduce excess idle connections rather than closing them all at once.
+      int maxTrim = Math.max(1, (excess + 3) / 4);
+      trimmedConnections = freeList.trim(minSize, usedSince, createdSince, maxTrim);
     } else if (createdSince > 0) {
       // trim only on maxAge
-      trimmedConnections = freeList.trim(0, createdSince, createdSince);
+      trimmedConnections = freeList.trim(0, createdSince, createdSince, Integer.MAX_VALUE);
     } else {
       trimmedConnections = List.of();
     }


### PR DESCRIPTION
Limit each idle-trim cycle to roughly one quarter of the excess connections, reducing aggressive post-deployment connection close bursts.