### PR TITLE
Increase maxInactiveTimeSecs to 900 seconds (15 mins, from prev 5 mins)

### DIFF
--- a/docs/guides/configuration-reference.md
+++ b/docs/guides/configuration-reference.md
@@ -92,7 +92,7 @@ Property keys are matched case-insensitively.
 |----------------|--------------|---------|-------------|
 | `waitTimeoutMillis(int)` | `waitTimeout` | `1000` | Millis a thread waits for a free connection once the pool is at max before throwing `ConnectionPoolExhaustedException`. |
 | `slowCreationMillis(int)` | `slowCreationMillis` | `100` | Log new physical connection creation at INFO when it exceeds this threshold. Set to `0` to disable slow creation logging. |
-| `maxInactiveTimeSecs(int)` | `maxInactiveTimeSecs` | `300` | Idle seconds after which a free connection can be trimmed back towards `minConnections`. |
+| `maxInactiveTimeSecs(int)` | `maxInactiveTimeSecs` | `900` | Idle seconds after which a free connection can be trimmed back towards `minConnections`. |
 | `maxAgeMinutes(int)` | `maxAgeMinutes` | `0` (unlimited) | Maximum age of a connection before it is trimmed regardless of activity. |
 | `trimPoolFreqSecs(int)` | `trimPoolFreqSecs` | `59` | How often the background trim check runs. |
 

--- a/docs/guides/monitoring-pool-metrics.md
+++ b/docs/guides/monitoring-pool-metrics.md
@@ -72,7 +72,7 @@ For most applications, **`size()` (`free() + busy()`) is the single most useful 
 
 - The pool **grows on demand**: when a connection is requested and none is free (and `size < maxConnections`),
   it creates a new one. So `size()` rises immediately to meet real concurrent demand.
-- The pool **trims slowly**: idle connections are only retired after `maxInactiveTimeSecs` (default 300s),
+- The pool **trims slowly**: idle connections are only retired after `maxInactiveTimeSecs` (default 900s),
   checked on the `trimPoolFreqSecs` cycle, and never below `minConnections`. This deliberate laziness
   avoids connection churn.
 

--- a/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
+++ b/ebean-datasource-api/src/main/java/io/ebean/datasource/DataSourceConfig.java
@@ -71,7 +71,7 @@ public class DataSourceConfig implements DataSourceBuilder.Settings {
   private boolean captureStackTrace;
   private int maxStackTraceSize = 5;
   private int leakTimeMinutes = 30;
-  private int maxInactiveTimeSecs = 300;
+  private int maxInactiveTimeSecs = 900;
   private int maxAgeMinutes = 0;
   private int trimPoolFreqSecs = 59;
   private int pstmtCacheSize = UNSET; // defaults to 300


### PR DESCRIPTION
Reduce connection churn during quieter periods by increasing the default maxInactiveTimeSecs from 300 to 900 seconds.